### PR TITLE
Add switch and plug as "lights"

### DIFF
--- a/custom_components/alexa_media/alexa_entity.py
+++ b/custom_components/alexa_media/alexa_entity.py
@@ -114,9 +114,11 @@ def is_light(appliance: dict[str, Any]) -> bool:
     """Is the given appliance a light controlled locally by an Echo."""
     return (
         is_local(appliance)
-        and ("LIGHT" in appliance.get("applianceTypes", [])
-             or "SWITCH" in appliance.get("applianceTypes", [])
-             or "SMARTPLUG" in appliance.get("applianceTypes", []))
+        and (
+            "LIGHT" in appliance.get("applianceTypes", [])
+            or "SWITCH" in appliance.get("applianceTypes", [])
+            or "SMARTPLUG" in appliance.get("applianceTypes", [])
+        )
         and has_capability(appliance, "Alexa.PowerController", "powerState")
     )
 

--- a/custom_components/alexa_media/alexa_entity.py
+++ b/custom_components/alexa_media/alexa_entity.py
@@ -114,7 +114,9 @@ def is_light(appliance: dict[str, Any]) -> bool:
     """Is the given appliance a light controlled locally by an Echo."""
     return (
         is_local(appliance)
-        and "LIGHT" in appliance.get("applianceTypes", [])
+        and ("LIGHT" in appliance.get("applianceTypes", [])
+             or "SWITCH" in appliance.get("applianceTypes", [])
+             or "SMARTPLUG" in appliance.get("applianceTypes", []))
         and has_capability(appliance, "Alexa.PowerController", "powerState")
     )
 


### PR DESCRIPTION
This is a hacky fix that allows Alexa to find Bluetooth (and probably Zigbee) plugs and switches that are directly connected to Alexa.

Basically, I fake them as lights, and they are found using the existing machinery for external lights.