### PR TITLE
feat: add Sengled Bluetooth bulbs to local Bluetooth check

### DIFF
--- a/custom_components/alexa_media/alexa_entity.py
+++ b/custom_components/alexa_media/alexa_entity.py
@@ -73,9 +73,9 @@ def is_local(appliance: dict[str, Any]) -> bool:
     if "ALEXA_VOICE_ENABLED" in appliance.get("applianceTypes", []):
         return not is_skill(appliance)
 
-    # Ledvance bulbs connected via bluetooth are hard to detect as locally connected
+    # Ledvance/Sengled bulbs connected via bluetooth are hard to detect as locally connected
     # There is probably a better way, but this works for now.
-    if appliance.get("manufacturerName") == "Ledvance":
+    if appliance.get("manufacturerName") == "Ledvance" or appliance.get("manufacturerName") == "Sengled":
         return not is_skill(appliance)
 
     # Zigbee devices are guaranteed to be local and have a particular pattern of id


### PR DESCRIPTION
Sengled Bluetooth bulbs were returning false from the `is_local` method and therefore were not being added to Home Assistant. Adding Sengled bulbs to the fix already established for Ledvance bulbs fixes the issue and allows Sengled bulbs to be added to Home Assistant when Include devices connected via Echo is checked in the configuration options window.

Fixes #2031