### PR TITLE
Honor DND status

### DIFF
--- a/custom_components/alexa_media/media_player.py
+++ b/custom_components/alexa_media/media_player.py
@@ -1292,6 +1292,11 @@ class AlexaClient(MediaPlayerDevice, AlexaMedia):
     @_catch_login_errors
     async def async_send_announcement(self, message, **kwargs):
         """Send announcement to the media player."""
+        
+        if self.dnd_state and kwargs.get("dnd", False):
+            _LOGGER.info("DND active for device %s, ignoring message", self.name)
+            return
+        
         if self.hass:
             self.hass.async_create_task(
                 self.alexa_api.send_announcement(

--- a/custom_components/alexa_media/notify.py
+++ b/custom_components/alexa_media/notify.py
@@ -287,6 +287,7 @@ class AlexaNotificationService(BaseNotificationService):
                                 queue_delay=self.hass.data[DATA_ALEXAMEDIA]["accounts"][
                                     account
                                 ]["options"].get(CONF_QUEUE_DELAY, DEFAULT_QUEUE_DELAY),
+                                dnd=data["dnd"],
                             )
                         )
                         break


### PR DESCRIPTION
Add "`dnd`" key in the notify service call to honor the DND status:

```yaml
service: notify.alexa_media_echo_dot_sala
data:
  message: test
  data:
    method: spoken
    type: announce
    dnd: true
```

If the new key is present and set to `true`, the message will not be played if the DND switch is active:

`2024-02-26 20:06:19.157 INFO (MainThread) [custom_components.alexa_media.media_player] DND active for device Echo Dot Sala, ignoring message`

In all other cases it will behave like before.
