### PR TITLE
feat: Add support for non-Amazon switches and plugs

### DIFF
--- a/custom_components/alexa_media/alexa_entity.py
+++ b/custom_components/alexa_media/alexa_entity.py
@@ -131,7 +131,10 @@ def is_switch(appliance: dict[str, Any]) -> bool:
     """Is the given appliance a switch controlled locally by an Echo."""
     return (
         is_local(appliance)
-        and "SMARTPLUG" in appliance.get("applianceTypes", [])
+        and (
+            "SMARTPLUG" in appliance.get("applianceTypes", [])
+            or "SWITCH" in appliance.get("applianceTypes", [])
+        )
         and appliance["manufacturerName"] == "Amazon"
         and has_capability(appliance, "Alexa.PowerController", "powerState")
     )

--- a/custom_components/alexa_media/alexa_entity.py
+++ b/custom_components/alexa_media/alexa_entity.py
@@ -135,7 +135,6 @@ def is_switch(appliance: dict[str, Any]) -> bool:
             "SMARTPLUG" in appliance.get("applianceTypes", [])
             or "SWITCH" in appliance.get("applianceTypes", [])
         )
-        and appliance["manufacturerName"] == "Amazon"
         and has_capability(appliance, "Alexa.PowerController", "powerState")
     )
 


### PR DESCRIPTION
This adds Alexa local switches as switches in addition to smart plugs. This also removes the requirement that local switches and plugs be Amazon-branded.  This allows Home Assistant to control things like [Sengled](https://www.amazon.com/Sengled-Plug-Compatible-Bluetooth-Required/dp/B093F6ZXYY) and other Bluetooth mesh plugs and switches directly connected to an Alexa device. 