### PR TITLE
Handle SMARTPLUG as lightswitch when defined in Alexa app as type "LIGHT"

### DIFF
--- a/custom_components/alexa_media/alexa_entity.py
+++ b/custom_components/alexa_media/alexa_entity.py
@@ -114,7 +114,10 @@ def is_light(appliance: dict[str, Any]) -> bool:
     """Is the given appliance a light controlled locally by an Echo."""
     return (
         is_local(appliance)
-        and "LIGHT" in appliance.get("applianceTypes", [])
+        and (
+            "LIGHT" in appliance.get("applianceTypes", []) 
+            or ("SMARTPLUG" in appliance.get("applianceTypes", []) and appliance.get("customerDefinedDeviceType") == "LIGHT")
+        )
         and has_capability(appliance, "Alexa.PowerController", "powerState")
     )
 


### PR DESCRIPTION
feat: handle SMARTPLUG as lightswitch when defined in Alexa app as type "LIGHT" (ie. SONOFF ZBMINI Extreme Zigbee switches or real smart plugs when used for lamps)