### PR TITLE
fix: fix instance_id deprecation

### DIFF
--- a/custom_components/alexa_media/helpers.py
+++ b/custom_components/alexa_media/helpers.py
@@ -17,6 +17,7 @@ from alexapy.alexalogin import AlexaLogin
 from homeassistant.const import CONF_EMAIL, CONF_URL
 from homeassistant.exceptions import ConditionErrorMessage
 from homeassistant.helpers.entity_component import EntityComponent
+from homeassistant.helpers.instance_id import async_get as async_get_instance_id
 import wrapt
 
 from .const import DATA_ALEXAMEDIA, EXCEPTION_TEMPLATE
@@ -271,7 +272,7 @@ async def calculate_uuid(hass, email: str, url: str) -> dict:
             if entry.data.get(CONF_EMAIL) == email and entry.data.get(CONF_URL) == url:
                 return_index = index
                 break
-    uuid = await hass.helpers.instance_id.async_get()
+    uuid = await async_get_instance_id(hass)
     result["uuid"] = hex(
         int(uuid, 16)
         # increment uuid for second accounts


### PR DESCRIPTION
Fixes

```
2024-05-04 14:17:07.813 WARNING (MainThread) [homeassistant.helpers.frame] Detected that custom integration 'alexa_media' accesses hass.helpers.instance_id. This is deprecated and will stop working in Home Assistant 2024.11, it should be updated to import functions used from instance_id directly at custom_components/alexa_media/helpers.py, line 274: uuid = await hass.helpers.instance_id.async_get(), please create a bug report at https://github.com/alandtse/alexa_media_player/issues
```

Partially fixes: https://github.com/alandtse/alexa_media_player/issues/2239