### PR TITLE
fix: fix lights being identified as switches (#2204)

### DIFF
--- a/custom_components/alexa_media/alexa_entity.py
+++ b/custom_components/alexa_media/alexa_entity.py
@@ -131,13 +131,14 @@ def is_contact_sensor(appliance: dict[str, Any]) -> bool:
     )
 
 def is_switch(appliance: dict[str, Any]) -> bool:
-    """Is the given appliance a switch controlled locally by an Echo."""
+    """Is the given appliance a switch controlled locally by an Echo, which ist not redeclared as a light."""
     return (
         is_local(appliance)
         and (
             "SMARTPLUG" in appliance.get("applianceTypes", [])
             or "SWITCH" in appliance.get("applianceTypes", [])
         )
+        and appliance.get("customerDefinedDeviceType") != "LIGHT"
         and has_capability(appliance, "Alexa.PowerController", "powerState")
     )
 

--- a/custom_components/alexa_media/alexa_entity.py
+++ b/custom_components/alexa_media/alexa_entity.py
@@ -114,7 +114,10 @@ def is_light(appliance: dict[str, Any]) -> bool:
     """Is the given appliance a light controlled locally by an Echo."""
     return (
         is_local(appliance)
-        and "LIGHT" in appliance.get("applianceTypes", [])
+        and (
+            "LIGHT" in appliance.get("applianceTypes", []) 
+            or ("SMARTPLUG" in appliance.get("applianceTypes", []) and appliance.get("customerDefinedDeviceType") == "LIGHT")
+        )
         and has_capability(appliance, "Alexa.PowerController", "powerState")
     )
 


### PR DESCRIPTION
fix: commit e3da18b to support switches as lights (if redeclared that way in the Alexa app) was incomplete due to conflicting change in commit 2344bcf (#2204)