### PR TITLE
fix: en.json somehow reverted to the old version

### DIFF
--- a/custom_components/alexa_media/translations/en.json
+++ b/custom_components/alexa_media/translations/en.json
@@ -6,20 +6,38 @@
       "reauth_successful": "Alexa Media Player successfully reauthenticated. Please ignore the \"Aborted\" message from HA."
     },
     "error": {
-      "2fa_key_invalid": "Invalid Built-In 2FA key",
       "connection_error": "Error connecting; check network and retry",
       "identifier_exists": "Email for Alexa URL already registered",
       "invalid_credentials": "Invalid credentials",
       "invalid_url": "URL is invalid: {message}",
-      "unable_to_connect_hass_url": "Unable to connect to Home Assistant url. Please check the External Url under Configuration -> General",
+      "2fa_key_invalid": "Invalid Built-In 2FA key",
+      "unable_to_connect_hass_url": "Unable to connect to Home Assistant URL. Please check the Internal URL under Configuration -> General",
       "unknown_error": "Unknown error: {message}"
     },
     "step": {
+      "user": {
+        "data": {
+          "url": "Amazon region domain (e.g., amazon.co.uk)",
+          "email": "Email Address",
+          "password": "Password",
+          "securitycode": "[%key_id:55616596%]",
+          "otp_secret": "Built-in 2FA App Key - This is 52 characters, not six!",
+          "hass_url": "Url to access Home Assistant",
+          "include_devices": "Included device (comma separated)",
+          "exclude_devices": "Excluded device (comma separated)",
+          "scan_interval": "Seconds between scans",
+          "queue_delay": "Seconds to wait to queue commands together",
+          "extended_entity_discovery": "Include devices connected via Echo",
+          "debug": "Advanced debugging"
+        },
+        "description": "Required *",
+        "title": "Alexa Media Player - Configuration"
+      },
       "proxy_warning": {
         "data": {
           "proxy_warning": "Ignore and Continue - I understand that no support for login issues are provided for bypassing this warning."
         },
-        "description": "The HA server cannot connect to the URL provided: {hass_url}.\n> {error}\n\nTo fix this, please confirm your **HA server** can reach {hass_url}. This field is from the External Url under Configuration -> General but you can try your internal url.\n\nIf you are **certain** your client can reach this url, you can bypass this warning.",
+        "description": "The HA server cannot connect to the URL provided: {hass_url}.\n> {error}\n\nTo fix this, please confirm your **HA server** can reach {hass_url}. This field is from the External URL under Configuration -> General but you can try your internal URL.\n\nIf you are **certain** your client can reach this URL, you can bypass this warning.",
         "title": "Alexa Media Player - Unable to Connect to HA URL"
       },
       "totp_register": {
@@ -28,22 +46,6 @@
         },
         "description": "**{email} - alexa.{url}**  \nHave you successfully confirmed an OTP from the Built-in 2FA App Key with Amazon?  \n >OTP Code {message}",
         "title": "Alexa Media Player - OTP Confirmation"
-      },
-      "user": {
-        "data": {
-          "debug": "Advanced debugging",
-          "email": "Email Address",
-          "exclude_devices": "Excluded device (comma separated)",
-          "hass_url": "Url to access Home Assistant",
-          "include_devices": "Included device (comma separated)",
-          "otp_secret": "Built-in 2FA App Key (automatically generate 2FA Codes). This is not six digits long.",
-          "password": "Password",
-          "scan_interval": "Seconds between scans",
-          "securitycode": "[%key_id:55616596%]",
-          "url": "Amazon region domain (e.g., amazon.co.uk)"
-        },
-        "description": "Please confirm the information below. For legacy configuration, disable `Use Login Proxy method` option.",
-        "title": "Alexa Media Player - Configuration"
       }
     }
   },
@@ -51,47 +53,53 @@
     "step": {
       "init": {
         "data": {
+          "hass_url": "Public URL to access Home Assistant (including trailing '/')",
+          "include_devices": "Included device (comma separated)",
+          "exclude_devices": "Excluded device (comma separated)",
+          "scan_interval": "Seconds between scans",
+          "queue_delay": "Seconds to wait to queue commands together",
           "extended_entity_discovery": "Include devices connected via Echo",
-          "public_url": "Public URL to access Home Assistant (including trailing '/')",
-          "queue_delay": "Seconds to wait to queue commands together"
-        }
+          "debug": "Advanced debugging"
+        },
+        "description": "Required *",
+        "title": "Alexa Media Player - Reconfiguration"
       }
     }
   },
   "services": {
     "clear_history": {
+      "name": "Clear Amazon Voice History",
       "description": "Clear last entries from Alexa Voice history for each Alexa account.",
       "fields": {
         "email": {
-          "description": "Accounts to clear. Empty will clear all.",
-          "name": "Email address"
+          "name": "Email address",
+          "description": "Accounts to clear. Empty will clear all."
         },
         "entries": {
-          "description": "Number of entries to clear from 1 to 50. If empty, clear 50.",
-          "name": "Number of Entries"
+          "name": "Number of Entries",
+          "description": "Number of entries to clear from 1 to 50. If empty, clear 50."
         }
-      },
-      "name": "Clear Amazon Voice History"
+      }
     },
     "force_logout": {
+      "name": "Force Logout",
       "description": "Force account to logout. Used mainly for debugging.",
       "fields": {
         "email": {
-          "description": "Accounts to clear. Empty will clear all.",
-          "name": "Email address"
+          "name": "Email address",
+          "description": "Accounts to clear. Empty will clear all."
         }
-      },
-      "name": "Force Logout"
+      }
     },
     "update_last_called": {
+      "name": "Update Last Called Sensor",
       "description": "Forces update of last_called echo device for each Alexa account.",
       "fields": {
         "email": {
-          "description": "List of Alexa accounts to update. If empty, will update all known accounts.",
-          "name": "Email address"
+          "name": "Email address",
+          "description": "List of Alexa accounts to update. If empty, will update all known accounts."
         }
-      },
-      "name": "Update Last Called Sensor"
+      }
     }
   }
 }


### PR DESCRIPTION
For some reason, en.json was still the old version and the configure options screen was missing all descriptions except one.