### PR TITLE
fix: fix AttributeError for 'AlexaMediaFlowHandler'

### DIFF
--- a/custom_components/alexa_media/config_flow.py
+++ b/custom_components/alexa_media/config_flow.py
@@ -805,7 +805,7 @@ class AlexaMediaFlowHandler(config_entries.ConfigFlow):
                 ): int,
                 vol.Optional(
                     CONF_QUEUE_DELAY,
-                    default=self.config_entry.options.get(CONF_QUEUE_DELAY, 1.5),
+                    default=self.config.get(CONF_QUEUE_DELAY, 1.5),
                 ): float,
                 vol.Optional(
                     CONF_EXTENDED_ENTITY_DISCOVERY,

--- a/custom_components/alexa_media/config_flow.py
+++ b/custom_components/alexa_media/config_flow.py
@@ -809,7 +809,7 @@ class AlexaMediaFlowHandler(config_entries.ConfigFlow):
                 ): float,
                 vol.Optional(
                     CONF_EXTENDED_ENTITY_DISCOVERY,
-                    default=self.config_entry.options.get(
+                    default=self.config.get(
                         CONF_EXTENDED_ENTITY_DISCOVERY,
                         DEFAULT_EXTENDED_ENTITY_DISCOVERY,
                     ),


### PR DESCRIPTION
Line 808 should be: default=self.config.get(CONF_QUEUE_DELAY, 1.5),
Line 812 should be default=self.config.get(CONF-EXTENDED_ENTITY_DISCOVERY, 60),