### PR TITLE
fix: use `config_flow` in OptionsFlow Handler

### DIFF
--- a/custom_components/alexa_media/config_flow.py
+++ b/custom_components/alexa_media/config_flow.py
@@ -830,9 +830,6 @@ class AlexaMediaFlowHandler(config_entries.ConfigFlow):
         return OptionsFlowHandler(config_entry)
 
 
-######
-
-
 class OptionsFlowHandler(config_entries.OptionsFlow):
     """Handle a option flow for Alexa Media."""
 
@@ -865,16 +862,16 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                 (
                     vol.Optional(
                         CONF_SCAN_INTERVAL,
-                        default=self.config_entry.data.get(CONF_SCAN_INTERVAL, 120),
+                        default=self.config_entry.data.get(
+                            CONF_SCAN_INTERVAL, 120
+                        ),
                     ),
                     int,
                 ),
                 (
                     vol.Optional(
                         CONF_QUEUE_DELAY,
-                        default=self.config_entry.data.get(
-                            CONF_QUEUE_DELAY, DEFAULT_QUEUE_DELAY
-                        ),
+                        default=self.config_entry.data.get(CONF_QUEUE_DELAY, DEFAULT_QUEUE_DELAY),
                     ),
                     float,
                 ),
@@ -890,8 +887,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                 ),
                 (
                     vol.Optional(
-                        CONF_DEBUG,
-                        default=self.config_entry.data.get(CONF_DEBUG, DEFAULT_DEBUG),
+                        CONF_DEBUG, default=self.config_entry.data.get(CONF_DEBUG, DEFAULT_DEBUG)
                     ),
                     bool,
                 ),
@@ -914,14 +910,10 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                 user_input[CONF_OTPSECRET] = self.config_entry.data[CONF_OTPSECRET]
             if CONF_OAUTH in self.config_entry.data:
                 user_input[CONF_OAUTH] = self.config_entry.data[CONF_OAUTH]
-            self.hass.config_entries.async_update_entry(
-                self.config_entry, data=user_input, options=self.config_entry.options
-            )
 
             self.hass.config_entries.async_update_entry(
                 self.config_entry, data=user_input, options=self.config_entry.options
             )
-
             return self.async_create_entry(title="", data={})
 
         return self.async_show_form(

--- a/custom_components/alexa_media/config_flow.py
+++ b/custom_components/alexa_media/config_flow.py
@@ -823,10 +823,13 @@ class AlexaMediaFlowHandler(config_entries.ConfigFlow):
 
     @staticmethod
     @callback
-    def async_get_options_flow(config_entry):
+    def async_get_options_flow(
+        config_entry: config_entries.ConfigEntry,
+    ) -> config_entries.OptionsFlow:
         """Get the options flow for this handler."""
         return OptionsFlowHandler(config_entry)
 
+######
 
 class OptionsFlowHandler(config_entries.OptionsFlow):
     """Handle a option flow for Alexa Media."""
@@ -846,22 +849,22 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                 (
                     vol.Optional(
                         CONF_INCLUDE_DEVICES,
-                        default=self.config.get(CONF_INCLUDE_DEVICES, ""),
+                        default=self.config_entry.data.get(CONF_INCLUDE_DEVICES, ""),
                     ),
                     str,
                 ),
                 (
                     vol.Optional(
                         CONF_EXCLUDE_DEVICES,
-                        default=self.config.get(CONF_EXCLUDE_DEVICES, ""),
+                        default=self.config_entry.data.get(CONF_EXCLUDE_DEVICES, ""),
                     ),
                     str,
                 ),
                 (
                     vol.Optional(
                         CONF_SCAN_INTERVAL,
-                        default=self.config.get(
-                            CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL
+                        default=self.config_entry.data.get(
+                            CONF_SCAN_INTERVAL, 120
                         ),
                     ),
                     int,
@@ -869,14 +872,14 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                 (
                     vol.Optional(
                         CONF_QUEUE_DELAY,
-                        default=self.config.get(CONF_QUEUE_DELAY, DEFAULT_QUEUE_DELAY),
+                        default=self.config_entry.data.get(CONF_QUEUE_DELAY, DEFAULT_QUEUE_DELAY),
                     ),
                     float,
                 ),
                 (
                     vol.Optional(
                         CONF_EXTENDED_ENTITY_DISCOVERY,
-                        default=self.config.get(
+                        default=self.config_entry.data.get(
                             CONF_EXTENDED_ENTITY_DISCOVERY,
                             DEFAULT_EXTENDED_ENTITY_DISCOVERY,
                         ),
@@ -885,7 +888,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                 ),
                 (
                     vol.Optional(
-                        CONF_DEBUG, default=self.config.get(CONF_DEBUG, DEFAULT_DEBUG)
+                        CONF_DEBUG, default=self.config_entry.data.get(CONF_DEBUG, DEFAULT_DEBUG)
                     ),
                     bool,
                 ),
@@ -911,6 +914,11 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
             self.hass.config_entries.async_update_entry(
                 self.config_entry, data=user_input, options=self.config_entry.options
             )
+            
+            self.hass.config_entries.async_update_entry(
+                self.config_entry, data=user_input, options=self.config_entry.options
+            )
+            
             return self.async_create_entry(title="", data={})
 
         return self.async_show_form(

--- a/custom_components/alexa_media/config_flow.py
+++ b/custom_components/alexa_media/config_flow.py
@@ -862,16 +862,16 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                 (
                     vol.Optional(
                         CONF_SCAN_INTERVAL,
-                        default=self.config_entry.data.get(
-                            CONF_SCAN_INTERVAL, 120
-                        ),
+                        default=self.config_entry.data.get(CONF_SCAN_INTERVAL, 120),
                     ),
                     int,
                 ),
                 (
                     vol.Optional(
                         CONF_QUEUE_DELAY,
-                        default=self.config_entry.data.get(CONF_QUEUE_DELAY, DEFAULT_QUEUE_DELAY),
+                        default=self.config_entry.data.get(
+                            CONF_QUEUE_DELAY, DEFAULT_QUEUE_DELAY
+                        ),
                     ),
                     float,
                 ),
@@ -887,7 +887,8 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                 ),
                 (
                     vol.Optional(
-                        CONF_DEBUG, default=self.config_entry.data.get(CONF_DEBUG, DEFAULT_DEBUG)
+                        CONF_DEBUG,
+                        default=self.config_entry.data.get(CONF_DEBUG, DEFAULT_DEBUG),
                     ),
                     bool,
                 ),

--- a/custom_components/alexa_media/config_flow.py
+++ b/custom_components/alexa_media/config_flow.py
@@ -829,7 +829,9 @@ class AlexaMediaFlowHandler(config_entries.ConfigFlow):
         """Get the options flow for this handler."""
         return OptionsFlowHandler(config_entry)
 
+
 ######
+
 
 class OptionsFlowHandler(config_entries.OptionsFlow):
     """Handle a option flow for Alexa Media."""
@@ -863,16 +865,16 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                 (
                     vol.Optional(
                         CONF_SCAN_INTERVAL,
-                        default=self.config_entry.data.get(
-                            CONF_SCAN_INTERVAL, 120
-                        ),
+                        default=self.config_entry.data.get(CONF_SCAN_INTERVAL, 120),
                     ),
                     int,
                 ),
                 (
                     vol.Optional(
                         CONF_QUEUE_DELAY,
-                        default=self.config_entry.data.get(CONF_QUEUE_DELAY, DEFAULT_QUEUE_DELAY),
+                        default=self.config_entry.data.get(
+                            CONF_QUEUE_DELAY, DEFAULT_QUEUE_DELAY
+                        ),
                     ),
                     float,
                 ),
@@ -888,7 +890,8 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                 ),
                 (
                     vol.Optional(
-                        CONF_DEBUG, default=self.config_entry.data.get(CONF_DEBUG, DEFAULT_DEBUG)
+                        CONF_DEBUG,
+                        default=self.config_entry.data.get(CONF_DEBUG, DEFAULT_DEBUG),
                     ),
                     bool,
                 ),
@@ -914,11 +917,11 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
             self.hass.config_entries.async_update_entry(
                 self.config_entry, data=user_input, options=self.config_entry.options
             )
-            
+
             self.hass.config_entries.async_update_entry(
                 self.config_entry, data=user_input, options=self.config_entry.options
             )
-            
+
             return self.async_create_entry(title="", data={})
 
         return self.async_show_form(


### PR DESCRIPTION
Three fixes/changes:
```
    def async_get_options_flow(
        config_entry: config_entries.ConfigEntry,
    ) -> config_entries.OptionsFlow:
```
```
    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
```
and `default=self.config_entry.data.get()` for all options.