### PR TITLE
fix: add callback decorator to hide threading warning

### DIFF
--- a/custom_components/alexa_media/sensor.py
+++ b/custom_components/alexa_media/sensor.py
@@ -423,6 +423,7 @@ class AlexaMediaNotificationSensor(SensorEntity):
                     dt.as_utc(self._attr_native_value),
                 )
 
+    @callback
     def _trigger_event(self, time_date) -> None:
         _LOGGER.debug(
             "%s:Firing %s at %s",


### PR DESCRIPTION
Fix issues #2306 and #2264 - error `alexa_media' calls hass.bus.async_fire from a thread other than the event loop` when alarms are dismissed or snoozed.
