### PR TITLE
fix: replace deprecated hass.components usage

### DIFF
--- a/custom_components/alexa_media/__init__.py
+++ b/custom_components/alexa_media/__init__.py
@@ -27,7 +27,10 @@ from alexapy import (
 )
 import async_timeout
 from homeassistant import util
-from homeassistant.components.persistent_notification import async_create
+from homeassistant.components.persistent_notification import (
+    async_create as async_create_persistent_notification,
+    async_dismiss as async_dismiss_persistent_notification,
+)
 from homeassistant.config_entries import SOURCE_IMPORT
 from homeassistant.const import (
     CONF_EMAIL,
@@ -1317,7 +1320,7 @@ async def async_unload_entry(hass, entry) -> bool:
             hass.data[DATA_ALEXAMEDIA].pop("services")
     if hass.data[DATA_ALEXAMEDIA].get("config_flows") == {}:
         _LOGGER.debug("Removing config_flows data")
-        hass.components.persistent_notification.async_dismiss(
+        async_dismiss_persistent_notification(
             f"alexa_media_{slugify(email)}{slugify((entry.data['url'])[7:])}"
         )
         hass.data[DATA_ALEXAMEDIA].pop("config_flows")
@@ -1390,8 +1393,7 @@ async def test_login_status(hass, config_entry, login) -> bool:
         elaspsed_time: str = str(datetime.now() - login.stats.get("login_timestamp"))
         api_calls: int = login.stats.get("api_calls")
         message += f"Relogin required after {elaspsed_time} and {api_calls} api calls."
-    # hass.components.persistent_notification.async_create(
-    async_create(
+    async_create_persistent_notification(
         title="Alexa Media Reauthentication Required",
         message=message,
         notification_id=f"alexa_media_{slugify(login.email)}{slugify(login.url[7:])}",


### PR DESCRIPTION
fix: use async_create for notification #2380 failed to address hass.components.persistent_notification.async_dismiss on line 1320 
See also #2382 
Styled as per hacs integration [PR #3528 Replace deprecated hass.components usage](https://github.com/hacs/integration/pull/3528/files#top)