### PR TITLE
fix: delete cookiefile when removing config entry

### DIFF
--- a/custom_components/alexa_media/__init__.py
+++ b/custom_components/alexa_media/__init__.py
@@ -1334,12 +1334,10 @@ async def async_unload_entry(hass, entry) -> bool:
         pickle = "/config/.storage/alexa_media." + email + ".pickle"
         try:
             os.remove(pickle)
-            _LOGGER.debug(f"Deleted pickle file {pickle}")
+            _LOGGER.debug(f"Deleted file {pickle}")
         except Exception as ex:
             _LOGGER.error(
-                "Pickle file {} could not be deleted. Verify it does not exist.".format(
-                    pickle, ex
-                )
+                "Failed to delete file {}: {}".format(pickle, ex)
             )
     else:
         _LOGGER.debug(

--- a/custom_components/alexa_media/__init__.py
+++ b/custom_components/alexa_media/__init__.py
@@ -1289,6 +1289,7 @@ async def setup_alexa(hass, config_entry, login_obj: AlexaLogin):
 async def async_unload_entry(hass, entry) -> bool:
     """Unload a config entry."""
     email = entry.data["email"]
+    login_obj = hass.data[DATA_ALEXAMEDIA]["accounts"][email]["login_obj"]
     _LOGGER.debug("Attempting to unload entry for %s", hide_email(email))
     for component in ALEXA_COMPONENTS + DEPENDENT_ALEXA_COMPONENTS:
         _LOGGER.debug("Forwarding unload entry to %s", component)
@@ -1330,13 +1331,15 @@ async def async_unload_entry(hass, entry) -> bool:
         _LOGGER.debug("Removing alexa_media data structure")
         if hass.data.get(DATA_ALEXAMEDIA):
             hass.data.pop(DATA_ALEXAMEDIA)
-        # Delete pickle file
-        pickle = "/config/.storage/alexa_media." + email + ".pickle"
+        # Delete cookiefile
         try:
-            os.remove(pickle)
-            _LOGGER.debug(f"Deleted file {pickle}")
+            await login_obj.delete_cookiefile()
+            _LOGGER.debug("Deleted cookiefile")
         except Exception as ex:
-            _LOGGER.error(f"Failed to delete file {pickle}: {ex}")
+            _LOGGER.error(
+                "Failed to delete cookiefile: %s",
+                ex,
+            )
     else:
         _LOGGER.debug(
             "Unable to remove alexa_media data structure: %s",

--- a/custom_components/alexa_media/__init__.py
+++ b/custom_components/alexa_media/__init__.py
@@ -8,15 +8,13 @@ https://community.home-assistant.io/t/echo-devices-alexa-as-media-player-testers
 """
 
 import asyncio
-import async_timeout
+from datetime import datetime, timedelta
+from json import JSONDecodeError, loads
 import logging
 import os
 import time
-import voluptuous as vol
-
-from datetime import datetime, timedelta
-from json import JSONDecodeError, loads
 from typing import Optional
+
 from alexapy import (
     AlexaAPI,
     AlexaLogin,
@@ -28,6 +26,7 @@ from alexapy import (
     hide_serial,
     obfuscate,
 )
+import async_timeout
 from homeassistant import util
 from homeassistant.components.persistent_notification import (
     async_create as async_create_persistent_notification,
@@ -51,6 +50,7 @@ from homeassistant.helpers.discovery import async_load_platform
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.util import dt, slugify
+import voluptuous as vol
 
 from .alexa_entity import AlexaEntityData, get_entity_data, parse_alexa_entities
 from .config_flow import in_progess_instances
@@ -1334,9 +1334,13 @@ async def async_unload_entry(hass, entry) -> bool:
         pickle = "/config/.storage/alexa_media." + email + ".pickle"
         try:
             os.remove(pickle)
-            _LOGGER.debug("Deleted pickle file {}".format(pickle))
+            _LOGGER.debug(f"Deleted pickle file {pickle}")
         except Exception as ex:
-            _LOGGER.error("Pickle file {} could not be deleted. Verify it does not exist.".format(pickle, ex))
+            _LOGGER.error(
+                "Pickle file {} could not be deleted. Verify it does not exist.".format(
+                    pickle, ex
+                )
+            )
     else:
         _LOGGER.debug(
             "Unable to remove alexa_media data structure: %s",

--- a/custom_components/alexa_media/__init__.py
+++ b/custom_components/alexa_media/__init__.py
@@ -1336,9 +1336,7 @@ async def async_unload_entry(hass, entry) -> bool:
             os.remove(pickle)
             _LOGGER.debug(f"Deleted file {pickle}")
         except Exception as ex:
-            _LOGGER.error(
-                "Failed to delete file {}: {}".format(pickle, ex)
-            )
+            _LOGGER.error(f"Failed to delete file {pickle}: {ex}")
     else:
         _LOGGER.debug(
             "Unable to remove alexa_media data structure: %s",


### PR DESCRIPTION
Delete pickle file when removing config entry as it's no longer needed and can cause issues when re-adding the integration entry.