### PR TITLE
fix: 'AlexaLogin' object has no attribute 'delete_cookiefile'

### DIFF
--- a/custom_components/alexa_media/__init__.py
+++ b/custom_components/alexa_media/__init__.py
@@ -1332,13 +1332,20 @@ async def async_unload_entry(hass, entry) -> bool:
         if hass.data.get(DATA_ALEXAMEDIA):
             hass.data.pop(DATA_ALEXAMEDIA)
         # Delete cookiefile
-        try:
-            await login_obj.delete_cookiefile()
-            _LOGGER.debug("Deleted cookiefile")
-        except Exception as ex:
-            _LOGGER.error(
-                "Failed to delete cookiefile: %s",
-                ex,
+        if callable(getattr(os,'delete_cookiefile', None)):
+          try:
+              await login_obj.delete_cookiefile()
+              _LOGGER.debug("Deleted cookiefile")
+          except Exception as ex:
+              _LOGGER.error(
+                  "Failed to delete cookiefile: %s",
+                  ex,
+              )
+        else:
+            _LOGGER.warn(
+                "Could not remove cookiefile: /config/.storage/alexa_media.%s.pickle."
+                "  Please manually delete the file.",
+                email,
             )
     else:
         _LOGGER.debug(

--- a/custom_components/alexa_media/__init__.py
+++ b/custom_components/alexa_media/__init__.py
@@ -1332,7 +1332,7 @@ async def async_unload_entry(hass, entry) -> bool:
         if hass.data.get(DATA_ALEXAMEDIA):
             hass.data.pop(DATA_ALEXAMEDIA)
         # Delete cookiefile
-        if callable(getattr(os,'delete_cookiefile', None)):
+        if callable(getattr(AlexaLogin,'delete_cookiefile', None)):
           try:
               await login_obj.delete_cookiefile()
               _LOGGER.debug("Deleted cookiefile")

--- a/custom_components/alexa_media/__init__.py
+++ b/custom_components/alexa_media/__init__.py
@@ -1332,15 +1332,15 @@ async def async_unload_entry(hass, entry) -> bool:
         if hass.data.get(DATA_ALEXAMEDIA):
             hass.data.pop(DATA_ALEXAMEDIA)
         # Delete cookiefile
-        if callable(getattr(AlexaLogin,'delete_cookiefile', None)):
-          try:
-              await login_obj.delete_cookiefile()
-              _LOGGER.debug("Deleted cookiefile")
-          except Exception as ex:
-              _LOGGER.error(
-                  "Failed to delete cookiefile: %s",
-                  ex,
-              )
+        if callable(getattr(AlexaLogin, "delete_cookiefile", None)):
+            try:
+                await login_obj.delete_cookiefile()
+                _LOGGER.debug("Deleted cookiefile")
+            except Exception as ex:
+                _LOGGER.error(
+                    "Failed to delete cookiefile: %s",
+                    ex,
+                )
         else:
             _LOGGER.warn(
                 "Could not remove cookiefile: /config/.storage/alexa_media.%s.pickle."


### PR DESCRIPTION
Check if AlexaLogin.delete_cookiefile exists before trying to call.
Fixes issue [#2470](https://github.com/alandtse/alexa_media_player/issues/2470) 