### PR TITLE
fix: 'AlexaLogin' object has no attribute 'delete_cookiefile' (#2471)

### DIFF
--- a/custom_components/alexa_media/__init__.py
+++ b/custom_components/alexa_media/__init__.py
@@ -1332,13 +1332,20 @@ async def async_unload_entry(hass, entry) -> bool:
         if hass.data.get(DATA_ALEXAMEDIA):
             hass.data.pop(DATA_ALEXAMEDIA)
         # Delete cookiefile
-        try:
-            await login_obj.delete_cookiefile()
-            _LOGGER.debug("Deleted cookiefile")
-        except Exception as ex:
-            _LOGGER.error(
-                "Failed to delete cookiefile: %s",
-                ex,
+        if callable(getattr(AlexaLogin, "delete_cookiefile", None)):
+            try:
+                await login_obj.delete_cookiefile()
+                _LOGGER.debug("Deleted cookiefile")
+            except Exception as ex:
+                _LOGGER.error(
+                    "Failed to delete cookiefile: %s",
+                    ex,
+                )
+        else:
+            _LOGGER.warn(
+                "Could not remove cookiefile: /config/.storage/alexa_media.%s.pickle."
+                "  Please manually delete the file.",
+                email,
             )
     else:
         _LOGGER.debug(


### PR DESCRIPTION
* Update __init__.py

Added `if callable(getattr(os,'delete_cookiefile', None)):` for compatibility with alexapy<=1.28.2

* Update __init__.py

Class was wrong
Needs to be `AlexaLogin,'delete_cookiefile'`

* style: auto fixes from pre-commit.com hooks

for more information, see https://pre-commit.ci

---------