### PR TITLE
fix: fix temperature native_unit_of_measurement

### DIFF
--- a/custom_components/alexa_media/alexa_entity.py
+++ b/custom_components/alexa_media/alexa_entity.py
@@ -403,8 +403,7 @@ def parse_color_from_coordinator(
     if value is not None:
         hue = value.get("hue", 0)
         saturation = value.get("saturation", 0)
-        brightness = value.get("brightness", 0)
-        return hue, saturation, brightness
+        return hue, saturation, 1
     return None
 
 

--- a/custom_components/alexa_media/alexa_entity.py
+++ b/custom_components/alexa_media/alexa_entity.py
@@ -350,10 +350,11 @@ def parse_temperature_from_coordinator(
     coordinator: DataUpdateCoordinator, entity_id: str
 ) -> Optional[str]:
     """Get the temperature of an entity from the coordinator data."""
-    value = parse_value_from_coordinator(
+    temperature = parse_value_from_coordinator(
         coordinator, entity_id, "Alexa.TemperatureSensor", "temperature"
     )
-    return value.get("value") if value and "value" in value else None
+    _LOGGER.debug("parse_temperature_from_coordinator: %s", temperature)
+    return temperature
 
 
 def parse_air_quality_from_coordinator(
@@ -402,7 +403,8 @@ def parse_color_from_coordinator(
     if value is not None:
         hue = value.get("hue", 0)
         saturation = value.get("saturation", 0)
-        return hue, saturation, 1
+        brightness = value.get("brightness", 0)
+        return hue, saturation, brightness
     return None
 
 

--- a/custom_components/alexa_media/sensor.py
+++ b/custom_components/alexa_media/sensor.py
@@ -265,9 +265,11 @@ class TemperatureSensor(SensorEntity, CoordinatorEntity):
             parse_temperature_from_coordinator(coordinator, entity_id)
         )
         self._attr_native_value = self._get_temperature_value(value_and_scale)
-        self._attr_native_unit_of_measurement = self._get_temperature_scale(value_and_scale)
+        self._attr_native_unit_of_measurement = self._get_temperature_scale(
+            value_and_scale
+        )
         _LOGGER.debug(
-            "Coordinator init: %s: %s %s", 
+            "Coordinator init: %s: %s %s",
             self._attr_name,
             self._attr_native_value,
             self._attr_native_unit_of_measurement,
@@ -288,9 +290,11 @@ class TemperatureSensor(SensorEntity, CoordinatorEntity):
             self.coordinator, self.alexa_entity_id
         )
         self._attr_native_value = self._get_temperature_value(value_and_scale)
-        self._attr_native_unit_of_measurement = self._get_temperature_scale(value_and_scale)
+        self._attr_native_unit_of_measurement = self._get_temperature_scale(
+            value_and_scale
+        )
         _LOGGER.debug(
-            "Coordinator update: %s: %s %s", 
+            "Coordinator update: %s: %s %s",
             self._attr_name,
             self._attr_native_value,
             self._attr_native_unit_of_measurement,
@@ -302,7 +306,7 @@ class TemperatureSensor(SensorEntity, CoordinatorEntity):
             _LOGGER.debug("TemperatureSensor value: %s", value.get("value"))
             return value.get("value")
         return None
-    
+
     def _get_temperature_scale(self, value):
         if value and "scale" in value:
             _LOGGER.debug("TemperatureSensor scale: %s", value.get("scale"))

--- a/custom_components/alexa_media/sensor.py
+++ b/custom_components/alexa_media/sensor.py
@@ -251,7 +251,7 @@ def lookup_device_info(account_dict, device_serial):
 class TemperatureSensor(SensorEntity, CoordinatorEntity):
     """A temperature sensor reported by an Echo."""
 
-    def __init__(self, coordinator, entity_id, name, media_player_device_id, ):
+    def __init__(self, coordinator, entity_id, name, media_player_device_id):
         """Initialize temperature sensor."""
         super().__init__(coordinator)
         self.alexa_entity_id = entity_id
@@ -364,7 +364,7 @@ class AirQualitySensor(SensorEntity, CoordinatorEntity):
             self.coordinator, self.alexa_entity_id, self._instance
         )
         super()._handle_coordinator_update()
-        
+
 
 class AlexaMediaNotificationSensor(SensorEntity):
     """Representation of Alexa Media sensors."""

--- a/custom_components/alexa_media/sensor.py
+++ b/custom_components/alexa_media/sensor.py
@@ -182,9 +182,10 @@ async def create_temperature_sensors(account_dict, temperature_entities):
     coordinator = account_dict["coordinator"]
     for temp in temperature_entities:
         _LOGGER.debug(
-            "Creating entity %s for a temperature sensor with name %s",
+            "Creating entity %s for a temperature sensor with name %s (%s)",
             temp["id"],
             temp["name"],
+            temp,
         )
         serial = temp["device_serial"]
         device_info = lookup_device_info(account_dict, serial)
@@ -250,20 +251,27 @@ def lookup_device_info(account_dict, device_serial):
 class TemperatureSensor(SensorEntity, CoordinatorEntity):
     """A temperature sensor reported by an Echo."""
 
-    def __init__(self, coordinator, entity_id, name, media_player_device_id):
+    def __init__(self, coordinator, entity_id, name, media_player_device_id, ):
         """Initialize temperature sensor."""
         super().__init__(coordinator)
         self.alexa_entity_id = entity_id
+        # Need to append "+temperature" because the Alexa entityId is for a physical device
+        # and a single physical device can have multiple HA entities
+        self._attr_unique_id = entity_id + "_temperature"
         self._attr_name = name + " Temperature"
         self._attr_device_class = SensorDeviceClass.TEMPERATURE
         self._attr_state_class = SensorStateClass.MEASUREMENT
-        self._attr_native_value: Optional[datetime.datetime] = (
+        value_and_scale: Optional[datetime.datetime] = (
             parse_temperature_from_coordinator(coordinator, entity_id)
         )
-        self._attr_native_unit_of_measurement: Optional[str] = UnitOfTemperature.CELSIUS
-        # This includes "_temperature" because the Alexa entityId is for a physical device
-        # A single physical device could have multiple HA entities
-        self._attr_unique_id = entity_id + "_temperature"
+        self._attr_native_value = self._get_temperature_value(value_and_scale)
+        self._attr_native_unit_of_measurement = self._get_temperature_scale(value_and_scale)
+        _LOGGER.debug(
+            "Coordinator init: %s: %s %s", 
+            self._attr_name,
+            self._attr_native_value,
+            self._attr_native_unit_of_measurement,
+        )
         self._attr_device_info = (
             {
                 "identifiers": {media_player_device_id},
@@ -276,10 +284,35 @@ class TemperatureSensor(SensorEntity, CoordinatorEntity):
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
-        self._attr_native_value = parse_temperature_from_coordinator(
+        value_and_scale = parse_temperature_from_coordinator(
             self.coordinator, self.alexa_entity_id
         )
+        self._attr_native_value = self._get_temperature_value(value_and_scale)
+        self._attr_native_unit_of_measurement = self._get_temperature_scale(value_and_scale)
+        _LOGGER.debug(
+            "Coordinator update: %s: %s %s", 
+            self._attr_name,
+            self._attr_native_value,
+            self._attr_native_unit_of_measurement,
+        )
         super()._handle_coordinator_update()
+
+    def _get_temperature_value(self, value):
+        if value and "value" in value:
+            _LOGGER.debug("TemperatureSensor value: %s", value.get("value"))
+            return value.get("value")
+        return None
+    
+    def _get_temperature_scale(self, value):
+        if value and "scale" in value:
+            _LOGGER.debug("TemperatureSensor scale: %s", value.get("scale"))
+            if value.get("scale") == "CELSIUS":
+                return UnitOfTemperature.CELSIUS
+            if value.get("scale") == "FAHRENHEIT":
+                return UnitOfTemperature.FAHRENHEIT
+            if value.get("scale") == "KELVIN":
+                return UnitOfTemperature.KELVIN
+        return None
 
 
 class AirQualitySensor(SensorEntity, CoordinatorEntity):
@@ -331,7 +364,7 @@ class AirQualitySensor(SensorEntity, CoordinatorEntity):
             self.coordinator, self.alexa_entity_id, self._instance
         )
         super()._handle_coordinator_update()
-
+        
 
 class AlexaMediaNotificationSensor(SensorEntity):
     """Representation of Alexa Media sensors."""


### PR DESCRIPTION
Fixes the 18 month old issue [Amazon Thermostat reports incorrect temperature #1890](https://github.com/alandtse/alexa_media_player/issues/1890)

Alexa temperature sensors were being hardcoded to `UnitOfTemperature.CELSIUS` thus preventing using sensors with FAHRENHEIT as their native unit.  These changes now correctly retrieve and use `scale` from the `"Alexa.TemperatureSensor", "temperature"` JSON string that Amazon issues in data refreshes: `parse_temperature_from_coordinator: {'value': 24.1, 'scale': 'CELSIUS'}`