### PR TITLE
feat: fire "alexa_media_last_called_event" after update

### DIFF
--- a/custom_components/alexa_media/media_player.py
+++ b/custom_components/alexa_media/media_player.py
@@ -420,7 +420,7 @@ class AlexaClient(MediaPlayerDevice, AlexaMedia):
                         "last_called": self.device_serial_number,
                         "timestamp": self._last_called_timestamp,
                         "summary": self._last_called_summary,
-                    }
+                    },
                 )
         elif "bluetooth_change" in event:
             if event_serial == self.device_serial_number:

--- a/custom_components/alexa_media/media_player.py
+++ b/custom_components/alexa_media/media_player.py
@@ -413,6 +413,15 @@ class AlexaClient(MediaPlayerDevice, AlexaMedia):
                     self.hass.data[DATA_ALEXAMEDIA]["accounts"][email]["http2"]
                 )
                 self.async_schedule_update_ha_state(force_refresh=force_refresh)
+            if self._last_called:
+                self.hass.bus.async_fire(
+                    "alexa_media_last_called_event",
+                    {
+                        "last_called": self.device_serial_number,
+                        "timestamp": self._last_called_timestamp,
+                        "summary": self._last_called_summary,
+                    }
+                )
         elif "bluetooth_change" in event:
             if event_serial == self.device_serial_number:
                 _LOGGER.debug(


### PR DESCRIPTION
This addition will allow scripts/automations which reference the `notify.alexa_media_last_called` service or the templated `sensor.last_alexa` sensor to wait for this event to fire before proceeding with their actions.  Previously, everyone was using a hard coded delay to ensure the update last_called had finished.  I had tried watching timestamps but this was only reliable when the timestamp actually changed which sometimes did not happen.  With this feature the reaction time to actions will be a variable delay yet reliable.  I've implemented this with a timeout on the wait for event and if it times out, I bypass all the notify/TTS actions.