### PR TITLE
fix: raise ConfigEntryNotReady on timeout

### DIFF
--- a/custom_components/alexa_media/media_player.py
+++ b/custom_components/alexa_media/media_player.py
@@ -181,9 +181,14 @@ async def async_setup_entry(hass, config_entry, async_add_devices):
                 _LOGGER.debug(
                     "%s: Loading config entry for %s", hide_email(account), component
                 )
-                await hass.config_entries.async_forward_entry_setups(
-                    config_entry, [component]
-                )
+                try: 
+                    await hass.config_entries.async_forward_entry_setups(
+                        config_entry, [component]
+                    )
+                except (asyncio.TimeoutError, TimeoutException) as ex:
+                    raise ConfigEntryNotReady(
+                            f"Timeout while loading config entry for {component}"
+                    ) from ex
         return True
     raise ConfigEntryNotReady
 

--- a/custom_components/alexa_media/media_player.py
+++ b/custom_components/alexa_media/media_player.py
@@ -181,13 +181,13 @@ async def async_setup_entry(hass, config_entry, async_add_devices):
                 _LOGGER.debug(
                     "%s: Loading config entry for %s", hide_email(account), component
                 )
-                try: 
+                try:
                     await hass.config_entries.async_forward_entry_setups(
                         config_entry, [component]
                     )
                 except (asyncio.TimeoutError, TimeoutException) as ex:
                     raise ConfigEntryNotReady(
-                            f"Timeout while loading config entry for {component}"
+                        f"Timeout while loading config entry for {component}"
                     ) from ex
         return True
     raise ConfigEntryNotReady


### PR DESCRIPTION
Closes #2283
PR #2336 only addressed loading the media_player component. 
This adds the same code change to media_player.py where switch, sensor, light, etc. components are loaded.
