### PR TITLE
fix: fix KeyError 'accounts' after uninstallation

### DIFF
--- a/custom_components/alexa_media/helpers.py
+++ b/custom_components/alexa_media/helpers.py
@@ -225,30 +225,23 @@ def report_relogin_required(hass, login, email) -> bool:
 
 
 def _existing_serials(hass, login_obj) -> list:
+    """Retrieve existing serial numbers for a given login object."""
     email: str = login_obj.email
-    existing_serials = (
-        list(
-            hass.data[DATA_ALEXAMEDIA]["accounts"][email]["entities"][
-                "media_player"
-            ].keys()
+    if DATA_ALEXAMEDIA in hass.data and "accounts" in hass.data[DATA_ALEXAMEDIA] and email in hass.data[DATA_ALEXAMEDIA]["accounts"]:
+        existing_serials = list(
+            hass.data[DATA_ALEXAMEDIA]["accounts"][email]["entities"]["media_player"].keys()
         )
-        if "entities" in (hass.data[DATA_ALEXAMEDIA]["accounts"][email])
-        else []
-    )
-    for serial in existing_serials:
-        device = hass.data[DATA_ALEXAMEDIA]["accounts"][email]["devices"][
-            "media_player"
-        ][serial]
-        if "appDeviceList" in device and device["appDeviceList"]:
-            apps = list(
-                map(
-                    lambda x: x["serialNumber"] if "serialNumber" in x else None,
-                    device["appDeviceList"],
-                )
-            )
-            # _LOGGER.debug("Combining %s with %s",
-            #               existing_serials, apps)
-            existing_serials = existing_serials + apps
+        device_data = hass.data[DATA_ALEXAMEDIA]["accounts"][email].get("devices", {}).get("media_player", {})
+        for serial in existing_serials:
+            device = device_data.get(serial, {})
+            if "appDeviceList" in device and device["appDeviceList"]:
+                apps = [
+                    x["serialNumber"] for x in device["appDeviceList"] if "serialNumber" in x
+                ]
+                existing_serials.extend(apps)
+    else:
+        _LOGGER.warning("No accounts data found for %s. Skipping serials retrieval.", email)
+        existing_serials = []
     return existing_serials
 
 

--- a/custom_components/alexa_media/helpers.py
+++ b/custom_components/alexa_media/helpers.py
@@ -227,20 +227,34 @@ def report_relogin_required(hass, login, email) -> bool:
 def _existing_serials(hass, login_obj) -> list:
     """Retrieve existing serial numbers for a given login object."""
     email: str = login_obj.email
-    if DATA_ALEXAMEDIA in hass.data and "accounts" in hass.data[DATA_ALEXAMEDIA] and email in hass.data[DATA_ALEXAMEDIA]["accounts"]:
+    if (
+        DATA_ALEXAMEDIA in hass.data
+        and "accounts" in hass.data[DATA_ALEXAMEDIA]
+        and email in hass.data[DATA_ALEXAMEDIA]["accounts"]
+    ):
         existing_serials = list(
-            hass.data[DATA_ALEXAMEDIA]["accounts"][email]["entities"]["media_player"].keys()
+            hass.data[DATA_ALEXAMEDIA]["accounts"][email]["entities"][
+                "media_player"
+            ].keys()
         )
-        device_data = hass.data[DATA_ALEXAMEDIA]["accounts"][email].get("devices", {}).get("media_player", {})
+        device_data = (
+            hass.data[DATA_ALEXAMEDIA]["accounts"][email]
+            .get("devices", {})
+            .get("media_player", {})
+        )
         for serial in existing_serials:
             device = device_data.get(serial, {})
             if "appDeviceList" in device and device["appDeviceList"]:
                 apps = [
-                    x["serialNumber"] for x in device["appDeviceList"] if "serialNumber" in x
+                    x["serialNumber"]
+                    for x in device["appDeviceList"]
+                    if "serialNumber" in x
                 ]
                 existing_serials.extend(apps)
     else:
-        _LOGGER.warning("No accounts data found for %s. Skipping serials retrieval.", email)
+        _LOGGER.warning(
+            "No accounts data found for %s. Skipping serials retrieval.", email
+        )
         existing_serials = []
     return existing_serials
 

--- a/custom_components/alexa_media/media_player.py
+++ b/custom_components/alexa_media/media_player.py
@@ -926,7 +926,7 @@ class AlexaClient(MediaPlayerDevice, AlexaMedia):
         except AttributeError:
             pass
         email = self._login.email
-        
+
         # Check if DATA_ALEXAMEDIA and 'accounts' exist
         accounts_data = self.hass.data.get(DATA_ALEXAMEDIA, {}).get("accounts", {})
         if (
@@ -937,9 +937,11 @@ class AlexaClient(MediaPlayerDevice, AlexaMedia):
             self._assumed_state = True
             self.available = False
             return
-        
+
         # Safely access the device
-        device = accounts_data[email]["devices"]["media_player"].get(self.device_serial_number)
+        device = accounts_data[email]["devices"]["media_player"].get(
+            self.device_serial_number
+        )
         if not device:
             _LOGGER.warning(
                 "Device serial number %s not found for account %s. Skipping update.",
@@ -948,19 +950,19 @@ class AlexaClient(MediaPlayerDevice, AlexaMedia):
             )
             self.available = False
             return
-        
+
         # Safely access websocket_commands
         seen_commands = (
             accounts_data[email]["websocket_commands"].keys()
             if "websocket_commands" in accounts_data[email]
             else None
         )
-        
+
         await self.refresh(device, no_throttle=True)
-        
+
         # Safely access 'http2' setting
         push_enabled = accounts_data[email].get("http2")
-        
+
         if (
             self.state in [MediaPlayerState.PLAYING]
             and

--- a/custom_components/alexa_media/media_player.py
+++ b/custom_components/alexa_media/media_player.py
@@ -776,8 +776,12 @@ class AlexaClient(MediaPlayerDevice, AlexaMedia):
                     else:
                         await self.alexa_api.set_bluetooth(devices["address"])
                     self._source = source
+        # Safely access 'http2' setting
         if not (
-            self.hass.data[DATA_ALEXAMEDIA]["accounts"][self._login.email]["http2"]
+            self.hass.data.get(DATA_ALEXAMEDIA, {})
+            .get("accounts", {})
+            .get(self._login.email, {})
+            .get("http2")
         ):
             await self.async_update()
 
@@ -922,35 +926,45 @@ class AlexaClient(MediaPlayerDevice, AlexaMedia):
         except AttributeError:
             pass
         email = self._login.email
+        
+        # Check if DATA_ALEXAMEDIA and 'accounts' exist
+        accounts_data = self.hass.data.get(DATA_ALEXAMEDIA, {}).get("accounts", {})
         if (
             self.entity_id is None  # Device has not initialized yet
-            or email not in self.hass.data[DATA_ALEXAMEDIA]["accounts"]
+            or email not in accounts_data
             or self._login.session.closed
         ):
             self._assumed_state = True
             self.available = False
             return
-        device = self.hass.data[DATA_ALEXAMEDIA]["accounts"][email]["devices"][
-            "media_player"
-        ][self.device_serial_number]
+        
+        # Safely access the device
+        device = accounts_data[email]["devices"]["media_player"].get(self.device_serial_number)
+        if not device:
+            _LOGGER.warning(
+                "Device serial number %s not found for account %s. Skipping update.",
+                self.device_serial_number,
+                hide_email(email),
+            )
+            self.available = False
+            return
+        
+        # Safely access websocket_commands
         seen_commands = (
-            self.hass.data[DATA_ALEXAMEDIA]["accounts"][email][
-                "websocket_commands"
-            ].keys()
-            if "websocket_commands"
-            in (self.hass.data[DATA_ALEXAMEDIA]["accounts"][email])
+            accounts_data[email]["websocket_commands"].keys()
+            if "websocket_commands" in accounts_data[email]
             else None
         )
-        await self.refresh(  # pylint: disable=unexpected-keyword-arg
-            device, no_throttle=True
-        )
-        push_enabled = (
-            self.hass.data[DATA_ALEXAMEDIA]["accounts"].get(email, {}).get("http2")
-        )
+        
+        await self.refresh(device, no_throttle=True)
+        
+        # Safely access 'http2' setting
+        push_enabled = accounts_data[email].get("http2")
+        
         if (
             self.state in [MediaPlayerState.PLAYING]
             and
-            #  only enable polling if websocket not connected
+            # Only enable polling if websocket not connected
             (
                 not push_enabled
                 or not seen_commands
@@ -970,7 +984,7 @@ class AlexaClient(MediaPlayerDevice, AlexaMedia):
             ):
                 _LOGGER.debug(
                     "%s: %s playing; scheduling update in %s seconds",
-                    hide_email(self._login.email),
+                    hide_email(email),
                     self.name,
                     PLAY_SCAN_INTERVAL,
                 )
@@ -983,9 +997,8 @@ class AlexaClient(MediaPlayerDevice, AlexaMedia):
             self._should_poll = False
             if not push_enabled:
                 _LOGGER.debug(
-                    "%s: Disabling polling and scheduling last update in"
-                    " 300 seconds for %s",
-                    hide_email(self._login.email),
+                    "%s: Disabling polling and scheduling last update in 300 seconds for %s",
+                    hide_email(email),
                     self.name,
                 )
                 async_call_later(
@@ -996,7 +1009,7 @@ class AlexaClient(MediaPlayerDevice, AlexaMedia):
             else:
                 _LOGGER.debug(
                     "%s: Disabling polling for %s",
-                    hide_email(self._login.email),
+                    hide_email(email),
                     self.name,
                 )
         self._last_update = util.utcnow()


### PR DESCRIPTION
### **Problem Description**
After uninstalling the Alexa Media Player integration, Home Assistant still attempts to update `media_player` entities associated with the removed integration. These entities try to access the `accounts` data structure within `hass.data[DATA_ALEXAMEDIA]`, which no longer exists post-removal. This leads to unhandled `KeyError` exceptions, causing repetitive error logs and potential instability.

These changes are essential in the following scenarios:
- **Integration Removal**: When users uninstall the Alexa Media Player integration, ensuring that no residual entities attempt to access its data.
- **Error Prevention**: To eliminate `KeyError: 'accounts'` exceptions that occur due to attempts to access removed data structures.

### **Solution**
To prevent these errors, the codebase has been modified to include checks that verify the existence of necessary data structures before attempting to access them. This ensures that once the Alexa Media Player integration is removed, no further attempts are made to access the non-existent `accounts` data, thereby eliminating the `KeyError` exceptions.

