### PR TITLE
fix: bump alexapy to 1.29.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # CHANGELOG
 
+## v4.13.5 (2024-10-19)
 
+### Fix
+
+* fix: bump alexapy to 1.29.3
+
+Fix login loop issue (1825583)([`1825583`](https://gitlab.com/keatontaylor/alexapy/-/commit/18255832673fd7e7639c114766e7aa4e74ffe42f))
 
 ## v4.7.7 (2023-10-08)
 

--- a/custom_components/alexa_media/const.py
+++ b/custom_components/alexa_media/const.py
@@ -15,7 +15,7 @@ from homeassistant.const import (
     PERCENTAGE,
 )
 
-__version__ = "4.13.4"
+__version__ = "4.13.5"
 PROJECT_URL = "https://github.com/alandtse/alexa_media_player/"
 ISSUE_URL = f"{PROJECT_URL}issues"
 NOTIFY_URL = f"{PROJECT_URL}wiki/Configuration%3A-Notification-Component#use-the-notifyalexa_media-service"

--- a/custom_components/alexa_media/const.py
+++ b/custom_components/alexa_media/const.py
@@ -15,7 +15,7 @@ from homeassistant.const import (
     PERCENTAGE,
 )
 
-__version__ = "4.13.5"
+__version__ = "4.13.4"
 PROJECT_URL = "https://github.com/alandtse/alexa_media_player/"
 ISSUE_URL = f"{PROJECT_URL}issues"
 NOTIFY_URL = f"{PROJECT_URL}wiki/Configuration%3A-Notification-Component#use-the-notifyalexa_media-service"

--- a/custom_components/alexa_media/manifest.json
+++ b/custom_components/alexa_media/manifest.json
@@ -8,6 +8,6 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/alandtse/alexa_media_player/issues",
   "loggers": ["alexapy", "authcaptureproxy"],
-  "requirements": ["alexapy==1.29.2", "packaging>=20.3", "wrapt>=1.14.0"],
-  "version": "4.13.4"
+  "requirements": ["alexapy==1.29.3", "packaging>=20.3", "wrapt>=1.14.0"],
+  "version": "4.13.5"
 }

--- a/custom_components/alexa_media/manifest.json
+++ b/custom_components/alexa_media/manifest.json
@@ -9,5 +9,5 @@
   "issue_tracker": "https://github.com/alandtse/alexa_media_player/issues",
   "loggers": ["alexapy", "authcaptureproxy"],
   "requirements": ["alexapy==1.29.3", "packaging>=20.3", "wrapt>=1.14.0"],
-  "version": "4.13.5"
+  "version": "4.13.4"
 }

--- a/poetry.lock
+++ b/poetry.lock
@@ -135,13 +135,13 @@ frozenlist = ">=1.1.0"
 
 [[package]]
 name = "alexapy"
-version = "1.29.2"
+version = "1.29.3"
 description = "Python API to control Amazon Echo Devices Programmatically."
 optional = false
 python-versions = "<4,>=3.11"
 files = [
-    {file = "alexapy-1.29.2-py3-none-any.whl", hash = "sha256:6dc1fb2979d1385aff1833681365f8c39cebbe3f9ceca2939c4695e65426c115"},
-    {file = "alexapy-1.29.2.tar.gz", hash = "sha256:36dead8b8062d8bd3e8f11f37edd196882951269c68cd6990762b415acb99d95"},
+    {file = "alexapy-1.29.3-py3-none-any.whl", hash = "sha256:14663bd0df41b7447b6de936e6ef0b0b4f44cd5958edc0b660fc93a1aae60bca"},
+    {file = "alexapy-1.29.3.tar.gz", hash = "sha256:8d554ef9afe30750be0269b5b51b6702da83382e7978f45915270090b5f2bdce"},
 ]
 
 [package.dependencies]
@@ -3611,4 +3611,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.11,<4.0"
-content-hash = "9cc60ca99e8a849cfbb96ef8d471e68360a45ca8a9e6e6ca8e6c25a104eb75f3"
+content-hash = "610de9c39bfb9fc6dd12887cb8fd9a0b22dc866440b3e169ab68fd4b93dd6826"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "alexa_media_player"
-version = "4.13.4"
+version = "4.13.5"
 description = "This is a custom component to allow control of Amazon Alexa devices in [Homeassistant](https://home-assistant.io) using the unofficial Alexa API."
 authors = [
   "Keaton Taylor <keatonstaylor@gmail.com>",
@@ -13,7 +13,7 @@ packages = [
 
 [tool.poetry.dependencies]
 python = ">=3.11,<4.0"
-alexapy = "1.29.2"
+alexapy = "1.29.3"
 aiohttp = ">=3.8.1"
 packaging = ">=20.3"
 wrapt = ">=1.12.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "alexa_media_player"
-version = "4.13.5"
+version = "4.13.4"
 description = "This is a custom component to allow control of Amazon Alexa devices in [Homeassistant](https://home-assistant.io) using the unofficial Alexa API."
 authors = [
   "Keaton Taylor <keatonstaylor@gmail.com>",


### PR DESCRIPTION
tested in local dev instance that login loop is indeed fixed with the bump

addresses the following
https://gitlab.com/keatontaylor/alexapy/-/releases/v1.29.3

mapped in this repo as
https://github.com/alandtse/alexa_media_player/issues/2514
https://github.com/alandtse/alexa_media_player/issues/2515