### PR TITLE
fix!: deprecate YAML configuration

### DIFF
--- a/custom_components/alexa_media/__init__.py
+++ b/custom_components/alexa_media/__init__.py
@@ -153,8 +153,6 @@ async def async_setup(hass, config, discovery_info=None):
         "restart Home Assistant and use the UI to configure it instead. "
         "Settings > Devices and services > Integrations > ADD INTEGRATION"
     )
-    """Future exit point"""
-    # return await async_initialize_integration(hass=hass, config=config)
 
     domainconfig = config.get(DOMAIN)
     for account in domainconfig[CONF_ACCOUNTS]:

--- a/custom_components/alexa_media/__init__.py
+++ b/custom_components/alexa_media/__init__.py
@@ -145,10 +145,10 @@ async def async_setup(hass, config, discovery_info=None):
         translation_key="deprecated_yaml_configuration",
         learn_more_url="https://github.com/alandtse/alexa_media_player/wiki/Configuration#configurationyaml",
     )
-    LOGGER.warning(
+    _LOGGER.warning(
         "YAML configuration of Alexa Media Player is deprecated "
-        "and will be removed in version 4.14.0.
-        There will be no automatic import of this. "
+        "and will be removed in version 4.14.0."
+        "There will be no automatic import of this. "
         "Please remove it from your configuration, "
         "restart Home Assistant and use the UI to configure it instead. "
         "Settings > Devices and services > Integrations > ADD INTEGRATION"

--- a/custom_components/alexa_media/__init__.py
+++ b/custom_components/alexa_media/__init__.py
@@ -49,6 +49,7 @@ from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import config_validation as cv, device_registry as dr
 from homeassistant.helpers.discovery import async_load_platform
 from homeassistant.helpers.dispatcher import async_dispatcher_send
+from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.util import dt, slugify
 import voluptuous as vol
@@ -133,6 +134,27 @@ async def async_setup(hass, config, discovery_info=None):
             "Nothing to import from configuration.yaml, loading from Integrations",
         )
         return True
+
+    async_create_issue(
+        hass,
+        DOMAIN,
+        "deprecated_yaml_configuration",
+        is_fixable=False,
+        issue_domain=DOMAIN,
+        severity=IssueSeverity.WARNING,
+        translation_key="deprecated_yaml_configuration",
+        learn_more_url="https://github.com/alandtse/alexa_media_player/wiki/Configuration#configurationyaml",
+    )
+    LOGGER.warning(
+        "YAML configuration of Alexa Media Player is deprecated "
+        "and will be removed in version 4.14.0.
+        There will be no automatic import of this. "
+        "Please remove it from your configuration, "
+        "restart Home Assistant and use the UI to configure it instead. "
+        "Settings > Devices and services > Integrations > ADD INTEGRATION"
+    )
+    """Future exit point"""
+    # return await async_initialize_integration(hass=hass, config=config)
 
     domainconfig = config.get(DOMAIN)
     for account in domainconfig[CONF_ACCOUNTS]:

--- a/custom_components/alexa_media/strings.json
+++ b/custom_components/alexa_media/strings.json
@@ -104,17 +104,6 @@
     }
   },
   "issues": {
-    "restart_required": {
-      "title": "Restart required",
-      "fix_flow": {
-        "step": {
-          "confirm_restart": {
-            "title": "Restart required",
-            "description": "Restart of Home Assistant is required to finish download/update of {name}, click submit to restart now."
-          }
-        }
-      }
-    },
     "deprecated_yaml_configuration": {
       "title": "YAML configuration is deprecated",
       "description": "YAML configuration of Alexa Media Player is deprecated\nand will be removed in version 4.14.0.\nThere will be no automatic import of this.\nPlease remove it from your configuration, restart Home Assistant and use the UI to configure it instead.\nSettings > Devices & services > Integrations > ADD INTEGRATION"

--- a/custom_components/alexa_media/strings.json
+++ b/custom_components/alexa_media/strings.json
@@ -102,5 +102,22 @@
         }
       }
     }
+  },
+  "issues": {
+    "restart_required": {
+      "title": "Restart required",
+      "fix_flow": {
+        "step": {
+          "confirm_restart": {
+            "title": "Restart required",
+            "description": "Restart of Home Assistant is required to finish download/update of {name}, click submit to restart now."
+          }
+        }
+      }
+    },
+    "deprecated_yaml_configuration": {
+      "title": "YAML configuration is deprecated",
+      "description": "YAML configuration of Alexa Media Player is deprecated\nand will be removed in version 4.14.0.\nThere will be no automatic import of this.\nPlease remove it from your configuration, restart Home Assistant and use the UI to configure it instead.\nSettings > Devices & services > Integrations > ADD INTEGRATION"
+    }
   }
 }

--- a/custom_components/alexa_media/strings.json
+++ b/custom_components/alexa_media/strings.json
@@ -6,47 +6,47 @@
       "reauth_successful": "Alexa Media Player successfully reauthenticated. Please ignore the \"Aborted\" message from HA."
     },
     "error": {
-      "2fa_key_invalid": "Invalid OTP Authenticator App key",
       "connection_error": "Error connecting; check network and retry",
       "identifier_exists": "Email for Alexa URL already registered",
       "invalid_credentials": "Invalid credentials",
       "invalid_url": "URL is invalid: {message}",
-      "unable_to_connect_hass_url": "Unable to connect to Home Assistant local URL. Please check the Internal URL under Settings > System > Network",
+      "2fa_key_invalid": "Invalid Built-In 2FA key",
+      "unable_to_connect_hass_url": "Unable to connect to Home Assistant URL. Please check the Internal URL under Configuration -> General",
       "unknown_error": "Unknown error: {message}"
     },
     "step": {
-      "proxy_warning": {
-        "data": {
-          "proxy_warning": "Ignore and Continue >>> I understand that NO support for login issues are provided when bypassing this warning! <<<"
-        },
-        "description": "The HA server cannot connect to the URL provided: {hass_url}.\n> {error}\n\nTo fix this, please confirm your **HA server** can reach {hass_url}. This field is from the Internal URL under Settings > System > Network.\n\nIf you are **certain** your client can reach this URL, you can bypass this warning.",
-        "title": "Alexa Media Player - Unable to Connect to HA Local URL"
-      },
-      "totp_register": {
-        "data": {
-          "registered": "Yes, OTP code was verified"
-        },
-        "description": "**{email} - alexa.{url}**  \nHave you verified the OTP code in Amazon 2SV?  \n >OTP Code: {message}",
-        "title": "Alexa Media Player - OTP Confirmation"
-      },
       "user": {
         "data": {
-          "url": "Your Amazon domain (e.g., amazon.co.uk)",
-          "hass_url": "Local URL to access Home Assistant (message}",
-          "public_url": "Internet URL to access Home Assistant",
+          "url": "Amazon region domain (e.g., amazon.co.uk)",
           "email": "Email Address",
           "password": "Password",
-          "otp_secret": "OTP Authenticator App Key (52 characters)",
           "securitycode": "[%key_id:55616596%]",
-          "include_devices": "Included device(s) (comma separated)",
-          "exclude_devices": "Excluded device(s) (comma separated)",
-          "queue_delay": "Multiple command queue delay (seconds)",
-          "scan_interval": "Scheduled polling interval (seconds)",
+          "otp_secret": "Built-in 2FA App Key - This is 52 characters, not six!",
+          "hass_url": "Local URL to access Home Assistant",
+          "public_url": "Public Url to access Home Assistant",
+          "include_devices": "Included device (comma separated)",
+          "exclude_devices": "Excluded device (comma separated)",
+          "scan_interval": "Seconds between scans",
+          "queue_delay": "Seconds to wait to queue commands together",
           "extended_entity_discovery": "Include devices connected via Echo",
           "debug": "Advanced debugging"
         },
-        "description": "Required fields * {message}",
+        "description": "Required *",
         "title": "Alexa Media Player - Configuration"
+      },
+      "proxy_warning": {
+        "data": {
+          "proxy_warning": "Ignore and Continue - I understand that no support for login issues are provided for bypassing this warning."
+        },
+        "description": "The HA server cannot connect to the URL provided: {hass_url}.\n> {error}\n\nTo fix this, please confirm your **HA server** can reach {hass_url}. This field is from the External URL under Configuration -> General but you can try your internal URL.\n\nIf you are **certain** your client can reach this URL, you can bypass this warning.",
+        "title": "Alexa Media Player - Unable to Connect to HA URL"
+      },
+      "totp_register": {
+        "data": {
+          "registered": "OTP from the Built-in 2FA App Key confirmed successfully."
+        },
+        "description": "**{email} - alexa.{url}**  \nHave you successfully confirmed an OTP from the Built-in 2FA App Key with Amazon?  \n >OTP Code {message}",
+        "title": "Alexa Media Player - OTP Confirmation"
       }
     }
   },
@@ -54,11 +54,11 @@
     "step": {
       "init": {
         "data": {
-          "public_url": "Public URL to access Home Assistant",
-          "include_devices": "Include device(s) (comma separated)",
-          "exclude_devices": "Exclude device(s) (comma separated)",
-          "queue_delay": "Multiple command queue delay (seconds)",
-          "scan_interval": "Scheduled polling interval (seconds)",
+          "public_url": "Public URL to access Home Assistant (including trailing '/')",
+          "include_devices": "Included device (comma separated)",
+          "exclude_devices": "Excluded device (comma separated)",
+          "scan_interval": "Seconds between scans",
+          "queue_delay": "Seconds to wait to queue commands together",
           "extended_entity_discovery": "Include devices connected via Echo",
           "debug": "Advanced debugging"
         },
@@ -68,6 +68,20 @@
     }
   },
   "services": {
+    "clear_history": {
+      "name": "Clear Amazon Voice History",
+      "description": "Clear last entries from Alexa Voice history for each Alexa account.",
+      "fields": {
+        "email": {
+          "name": "Email address",
+          "description": "Accounts to clear. Empty will clear all."
+        },
+        "entries": {
+          "name": "Number of Entries",
+          "description": "Number of entries to clear from 1 to 50. If empty, clear 50."
+        }
+      }
+    },
     "force_logout": {
       "name": "Force Logout",
       "description": "Force account to logout. Used mainly for debugging.",

--- a/custom_components/alexa_media/strings.json
+++ b/custom_components/alexa_media/strings.json
@@ -6,47 +6,47 @@
       "reauth_successful": "Alexa Media Player successfully reauthenticated. Please ignore the \"Aborted\" message from HA."
     },
     "error": {
+      "2fa_key_invalid": "Invalid OTP Authenticator App key",
       "connection_error": "Error connecting; check network and retry",
       "identifier_exists": "Email for Alexa URL already registered",
       "invalid_credentials": "Invalid credentials",
       "invalid_url": "URL is invalid: {message}",
-      "2fa_key_invalid": "Invalid Built-In 2FA key",
-      "unable_to_connect_hass_url": "Unable to connect to Home Assistant URL. Please check the Internal URL under Configuration -> General",
+      "unable_to_connect_hass_url": "Unable to connect to Home Assistant local URL. Please check the Internal URL under Settings > System > Network",
       "unknown_error": "Unknown error: {message}"
     },
     "step": {
-      "user": {
-        "data": {
-          "url": "Amazon region domain (e.g., amazon.co.uk)",
-          "email": "Email Address",
-          "password": "Password",
-          "securitycode": "[%key_id:55616596%]",
-          "otp_secret": "Built-in 2FA App Key - This is 52 characters, not six!",
-          "hass_url": "Local URL to access Home Assistant",
-          "public_url": "Public Url to access Home Assistant",
-          "include_devices": "Included device (comma separated)",
-          "exclude_devices": "Excluded device (comma separated)",
-          "scan_interval": "Seconds between scans",
-          "queue_delay": "Seconds to wait to queue commands together",
-          "extended_entity_discovery": "Include devices connected via Echo",
-          "debug": "Advanced debugging"
-        },
-        "description": "Required *",
-        "title": "Alexa Media Player - Configuration"
-      },
       "proxy_warning": {
         "data": {
-          "proxy_warning": "Ignore and Continue - I understand that no support for login issues are provided for bypassing this warning."
+          "proxy_warning": "Ignore and Continue >>> I understand that NO support for login issues are provided when bypassing this warning! <<<"
         },
-        "description": "The HA server cannot connect to the URL provided: {hass_url}.\n> {error}\n\nTo fix this, please confirm your **HA server** can reach {hass_url}. This field is from the External URL under Configuration -> General but you can try your internal URL.\n\nIf you are **certain** your client can reach this URL, you can bypass this warning.",
-        "title": "Alexa Media Player - Unable to Connect to HA URL"
+        "description": "The HA server cannot connect to the URL provided: {hass_url}.\n> {error}\n\nTo fix this, please confirm your **HA server** can reach {hass_url}. This field is from the Internal URL under Settings > System > Network.\n\nIf you are **certain** your client can reach this URL, you can bypass this warning.",
+        "title": "Alexa Media Player - Unable to Connect to HA Local URL"
       },
       "totp_register": {
         "data": {
-          "registered": "OTP from the Built-in 2FA App Key confirmed successfully."
+          "registered": "Yes, OTP code was verified"
         },
-        "description": "**{email} - alexa.{url}**  \nHave you successfully confirmed an OTP from the Built-in 2FA App Key with Amazon?  \n >OTP Code {message}",
+        "description": "**{email} - alexa.{url}**  \nHave you verified the OTP code in Amazon 2SV?  \n >OTP Code: {message}",
         "title": "Alexa Media Player - OTP Confirmation"
+      },
+      "user": {
+        "data": {
+          "url": "Your Amazon domain (e.g., amazon.co.uk)",
+          "hass_url": "Local URL to access Home Assistant (message}",
+          "public_url": "Internet URL to access Home Assistant",
+          "email": "Email Address",
+          "password": "Password",
+          "otp_secret": "OTP Authenticator App Key (52 characters)",
+          "securitycode": "[%key_id:55616596%]",
+          "include_devices": "Included device(s) (comma separated)",
+          "exclude_devices": "Excluded device(s) (comma separated)",
+          "queue_delay": "Multiple command queue delay (seconds)",
+          "scan_interval": "Scheduled polling interval (seconds)",
+          "extended_entity_discovery": "Include devices connected via Echo",
+          "debug": "Advanced debugging"
+        },
+        "description": "Required fields * {message}",
+        "title": "Alexa Media Player - Configuration"
       }
     }
   },
@@ -54,11 +54,11 @@
     "step": {
       "init": {
         "data": {
-          "public_url": "Public URL to access Home Assistant (including trailing '/')",
-          "include_devices": "Included device (comma separated)",
-          "exclude_devices": "Excluded device (comma separated)",
-          "scan_interval": "Seconds between scans",
-          "queue_delay": "Seconds to wait to queue commands together",
+          "public_url": "Public URL to access Home Assistant",
+          "include_devices": "Include device(s) (comma separated)",
+          "exclude_devices": "Exclude device(s) (comma separated)",
+          "queue_delay": "Multiple command queue delay (seconds)",
+          "scan_interval": "Scheduled polling interval (seconds)",
           "extended_entity_discovery": "Include devices connected via Echo",
           "debug": "Advanced debugging"
         },
@@ -68,20 +68,6 @@
     }
   },
   "services": {
-    "clear_history": {
-      "name": "Clear Amazon Voice History",
-      "description": "Clear last entries from Alexa Voice history for each Alexa account.",
-      "fields": {
-        "email": {
-          "name": "Email address",
-          "description": "Accounts to clear. Empty will clear all."
-        },
-        "entries": {
-          "name": "Number of Entries",
-          "description": "Number of entries to clear from 1 to 50. If empty, clear 50."
-        }
-      }
-    },
     "force_logout": {
       "name": "Force Logout",
       "description": "Force account to logout. Used mainly for debugging.",


### PR DESCRIPTION
YAML configuration is deprecated. Users must manually remove `alexa_media` from `configuration.yaml` file and add the integration via UI to avoid warning messages and future failure.

BREAKING CHANGE: Deprecate YAML configuration 
