### PR TITLE
fix: Refreshing <entity unknown.unknown=unknown> in debug log

### DIFF
--- a/custom_components/alexa_media/media_player.py
+++ b/custom_components/alexa_media/media_player.py
@@ -585,7 +585,10 @@ class AlexaClient(MediaPlayerDevice, AlexaMedia):
             self._set_authentication_details(device["auth_info"])
         session = None
         if self.available:
-            _LOGGER.debug("%s: Refreshing %s", self.account, self)
+            _LOGGER.debug(
+                "%s: Refreshing %s",
+                self.account,
+                self if device is None else self._device_name)
             self._assumed_state = False
             if "PAIR_BT_SOURCE" in self._capabilities:
                 self._source = self._get_source()

--- a/custom_components/alexa_media/media_player.py
+++ b/custom_components/alexa_media/media_player.py
@@ -588,7 +588,8 @@ class AlexaClient(MediaPlayerDevice, AlexaMedia):
             _LOGGER.debug(
                 "%s: Refreshing %s",
                 self.account,
-                self if device is None else self._device_name)
+                self if device is None else self._device_name,
+            )
             self._assumed_state = False
             if "PAIR_BT_SOURCE" in self._capabilities:
                 self._source = self._get_source()


### PR DESCRIPTION
This cleans up a media_player DEBUG log entry.
Before:
```
DEBUG (MainThread) [custom_components.alexa_media.media_player] d****l@b******a: Refreshing <entity unknown.unknown=unknown>
```
After:
```
DEBUG (MainThread) [custom_components.alexa_media.media_player] d****l@b******a: Refreshing: Garage Echo Dot
```