### PR TITLE
fix: home-assistant-matter-hub duplicated entities

### DIFF
--- a/custom_components/alexa_media/alexa_entity.py
+++ b/custom_components/alexa_media/alexa_entity.py
@@ -64,6 +64,13 @@ def is_local(appliance: dict[str, Any]) -> bool:
     There is probably a better way to prevent that, but this works.
     """
 
+    if appliance.get("manufacturerName") == "TestVendor":
+        # Home-Assistant-Matter-Hub is a new add-on (2024-10-27) which exposes selected
+        # HA entities to Alexa as Matter devices conected locally via Amazon Echo.
+        # "connectedVia" is not None so they need to be ignored to prevent duplicating them back into HA.
+        _LOGGER.debug("alexa_entity: Return is_local False for manufacturer \"%s\"", appliance.get("manufacturerName"))
+        return False
+        
     if appliance.get("connectedVia"):
         # connectedVia is a flag that determines which Echo devices holds the connection. Its blank for
         # skill derived devices and includes an Echo name for zigbee and local devices.

--- a/custom_components/alexa_media/alexa_entity.py
+++ b/custom_components/alexa_media/alexa_entity.py
@@ -66,7 +66,7 @@ def is_local(appliance: dict[str, Any]) -> bool:
 
     if appliance.get("manufacturerName") == "TestVendor":
         # Home-Assistant-Matter-Hub is a new add-on (2024-10-27) which exposes selected
-        # HA entities to Alexa as Matter devices conected locally via Amazon Echo.
+        # HA entities to Alexa as Matter devices connected locally via Amazon Echo.
         # "connectedVia" is not None so they need to be ignored to prevent duplicating them back into HA.
         _LOGGER.debug(
             'alexa_entity: Return is_local False for manufacturer "%s"',

--- a/custom_components/alexa_media/alexa_entity.py
+++ b/custom_components/alexa_media/alexa_entity.py
@@ -64,12 +64,12 @@ def is_local(appliance: dict[str, Any]) -> bool:
     There is probably a better way to prevent that, but this works.
     """
 
-    if appliance.get("manufacturerName") == "TestVendor":
+    if appliance.get("manufacturerName") == "t0bst4r":
         # Home-Assistant-Matter-Hub is a new add-on (2024-10-27) which exposes selected
         # HA entities to Alexa as Matter devices connected locally via Amazon Echo.
         # "connectedVia" is not None so they need to be ignored to prevent duplicating them back into HA.
         _LOGGER.debug(
-            'alexa_entity: Return is_local False for manufacturer "%s"',
+            'alexa_entity is_local: Return False for Home-Assistant-Matter-Hub manufacturer: "%s"',
             appliance.get("manufacturerName"),
         )
         return False

--- a/custom_components/alexa_media/alexa_entity.py
+++ b/custom_components/alexa_media/alexa_entity.py
@@ -68,9 +68,12 @@ def is_local(appliance: dict[str, Any]) -> bool:
         # Home-Assistant-Matter-Hub is a new add-on (2024-10-27) which exposes selected
         # HA entities to Alexa as Matter devices conected locally via Amazon Echo.
         # "connectedVia" is not None so they need to be ignored to prevent duplicating them back into HA.
-        _LOGGER.debug("alexa_entity: Return is_local False for manufacturer \"%s\"", appliance.get("manufacturerName"))
+        _LOGGER.debug(
+            'alexa_entity: Return is_local False for manufacturer "%s"',
+            appliance.get("manufacturerName"),
+        )
         return False
-        
+
     if appliance.get("connectedVia"):
         # connectedVia is a flag that determines which Echo devices holds the connection. Its blank for
         # skill derived devices and includes an Echo name for zigbee and local devices.


### PR DESCRIPTION
Force "TestVendor" in the `is_local` check to return `False` since the entities discovered by Echo devices via Matter discovery are duplicates of already existing HA entities.

Fixes issue #2709 