### PR TITLE
fix: Clear error message for music streaming

### DIFF
--- a/custom_components/alexa_media/const.py
+++ b/custom_components/alexa_media/const.py
@@ -117,9 +117,7 @@ STREAMING_ERROR_MESSAGE = (
 PUBLIC_URL_ERROR_MESSAGE = (
     "To send TTS, please set the public URL in integration configuration."
 )
-ANNOUNCE_ERROR_MESSAGE = (
-    "To send TTS, please set Announce=true."
-)
+ANNOUNCE_ERROR_MESSAGE = "To send TTS, please set Announce=true."
 STARTUP = f"""
 -------------------------------------------------------------------
 {DOMAIN}

--- a/custom_components/alexa_media/const.py
+++ b/custom_components/alexa_media/const.py
@@ -114,6 +114,12 @@ STREAMING_ERROR_MESSAGE = (
     "Sorry folks! Amazon doesn't allow streaming music like this. "
     "Please take it up with them!"
 )
+PUBLIC_URL_ERROR_MESSAGE = (
+    "To send TTS, please set the public URL in integration configuration."
+)
+ANNOUNCE_ERROR_MESSAGE = (
+    "To send TTS, please set Announce=true."
+)
 STARTUP = f"""
 -------------------------------------------------------------------
 {DOMAIN}

--- a/custom_components/alexa_media/const.py
+++ b/custom_components/alexa_media/const.py
@@ -110,6 +110,10 @@ RECURRING_PATTERN_ISO_SET = {
 ATTR_MESSAGE = "message"
 ATTR_EMAIL = "email"
 ATTR_NUM_ENTRIES = "entries"
+STREAMING_ERROR_MESSAGE = (
+    "Sorry folks! Amazon doesn't allow streaming music like this. "
+    "Please take it up with them!"
+)
 STARTUP = f"""
 -------------------------------------------------------------------
 {DOMAIN}

--- a/custom_components/alexa_media/media_player.py
+++ b/custom_components/alexa_media/media_player.py
@@ -47,6 +47,8 @@ from .const import (
     MODEL_IDS,
     PLAY_SCAN_INTERVAL,
     STREAMING_ERROR_MESSAGE,
+    PUBLIC_URL_ERROR_MESSAGE,
+    ANNOUNCE_ERROR_MESSAGE,
     UPLOAD_PATH,
 )
 from .helpers import _catch_login_errors, add_devices
@@ -1439,8 +1441,8 @@ class AlexaClient(MediaPlayerDevice, AlexaMedia):
                 f"<audio src='{public_url}local/alexa_tts{output_file_name}' />"
             )
         else:
-            await self.async_send_tts("To send TTS, please set Announce=true.")
-            _LOGGER.warning("To send TTS, please set Announce=true.")
+            await self.async_send_tts(ANNOUNCE_ERROR_MESSAGE)
+            _LOGGER.warning(ANNOUNCE_ERROR_MESSAGE)
 
     @_catch_login_errors
     async def async_play_media(self, media_type, media_id, enqueue=None, **kwargs):
@@ -1455,12 +1457,8 @@ class AlexaClient(MediaPlayerDevice, AlexaMedia):
         if media_type == "music":
             if not public_url:
                 # Log and notify for missing public URL
-                _LOGGER.warning(
-                    "To send TTS, please set the public URL in integration configuration."
-                )
-                await self.async_send_tts(
-                    "To send TTS, please set the public URL in integration configuration."
-                )
+                _LOGGER.warning(PUBLIC_URL_ERROR_MESSAGE)
+                await self.async_send_tts(PUBLIC_URL_ERROR_MESSAGE)
             else:
                 # Log and notify for Amazon restriction on streaming music
                 _LOGGER.warning(STREAMING_ERROR_MESSAGE)

--- a/custom_components/alexa_media/media_player.py
+++ b/custom_components/alexa_media/media_player.py
@@ -41,14 +41,14 @@ from . import (
 )
 from .alexa_media import AlexaMedia
 from .const import (
+    ANNOUNCE_ERROR_MESSAGE,
     DEPENDENT_ALEXA_COMPONENTS,
     MIN_TIME_BETWEEN_FORCED_SCANS,
     MIN_TIME_BETWEEN_SCANS,
     MODEL_IDS,
     PLAY_SCAN_INTERVAL,
-    STREAMING_ERROR_MESSAGE,
     PUBLIC_URL_ERROR_MESSAGE,
-    ANNOUNCE_ERROR_MESSAGE,
+    STREAMING_ERROR_MESSAGE,
     UPLOAD_PATH,
 )
 from .helpers import _catch_login_errors, add_devices

--- a/custom_components/alexa_media/media_player.py
+++ b/custom_components/alexa_media/media_player.py
@@ -83,6 +83,7 @@ STREAMING_ERROR_MESSAGE = (
     "Please take it up with them!"
 )
 
+
 async def create_www_directory(hass: HomeAssistant):
     """Create www directory."""
     paths = [

--- a/custom_components/alexa_media/media_player.py
+++ b/custom_components/alexa_media/media_player.py
@@ -46,8 +46,8 @@ from .const import (
     MIN_TIME_BETWEEN_SCANS,
     MODEL_IDS,
     PLAY_SCAN_INTERVAL,
-    UPLOAD_PATH,
     STREAMING_ERROR_MESSAGE,
+    UPLOAD_PATH,
 )
 from .helpers import _catch_login_errors, add_devices
 

--- a/custom_components/alexa_media/media_player.py
+++ b/custom_components/alexa_media/media_player.py
@@ -78,6 +78,10 @@ _LOGGER = logging.getLogger(__name__)
 
 DEPENDENCIES = [ALEXA_DOMAIN]
 
+STREAMING_ERROR_MESSAGE = (
+    "Sorry folks! Amazon doesn't allow streaming music like this. "
+    "Please take it up with them!"
+)
 
 async def create_www_directory(hass: HomeAssistant):
     """Create www directory."""
@@ -1388,14 +1392,8 @@ class AlexaClient(MediaPlayerDevice, AlexaMedia):
 
         if media_type == "music":
             # Log and notify for Amazon restriction on streaming music
-            _LOGGER.warning(
-                "Sorry folks! Amazon doesn't allow streaming music like this. "
-                "Please take it up with them!"
-            )
-            await self.async_send_tts(
-                "Sorry folks! Amazon doesn't allow streaming music like this. "
-                "Please take it up with them!"
-            )
+            _LOGGER.warning(STREAMING_ERROR_MESSAGE)
+            await self.async_send_tts(STREAMING_ERROR_MESSAGE)
             return
 
         if kwargs.get(ATTR_MEDIA_ANNOUNCE):
@@ -1468,14 +1466,8 @@ class AlexaClient(MediaPlayerDevice, AlexaMedia):
                 )
             else:
                 # Log and notify for Amazon restriction on streaming music
-                _LOGGER.warning(
-                    "Sorry folks! Amazon doesn't allow streaming music like this. "
-                    "Please take it up with them!"
-                )
-                await self.async_send_tts(
-                    "Sorry folks! Amazon doesn't allow streaming music like this. "
-                    "Please take it up with them!"
-                )
+                _LOGGER.warning(STREAMING_ERROR_MESSAGE)
+                await self.async_send_tts(STREAMING_ERROR_MESSAGE)
         elif media_type == "sequence":
             _LOGGER.debug(
                 "%s: %s:Running sequence %s with queue_delay %s",

--- a/custom_components/alexa_media/media_player.py
+++ b/custom_components/alexa_media/media_player.py
@@ -47,6 +47,7 @@ from .const import (
     MODEL_IDS,
     PLAY_SCAN_INTERVAL,
     UPLOAD_PATH,
+    STREAMING_ERROR_MESSAGE,
 )
 from .helpers import _catch_login_errors, add_devices
 
@@ -77,11 +78,6 @@ SUPPORT_ALEXA = (
 _LOGGER = logging.getLogger(__name__)
 
 DEPENDENCIES = [ALEXA_DOMAIN]
-
-STREAMING_ERROR_MESSAGE = (
-    "Sorry folks! Amazon doesn't allow streaming music like this. "
-    "Please take it up with them!"
-)
 
 
 async def create_www_directory(hass: HomeAssistant):

--- a/custom_components/alexa_media/media_player.py
+++ b/custom_components/alexa_media/media_player.py
@@ -1375,7 +1375,9 @@ class AlexaClient(MediaPlayerDevice, AlexaMedia):
             )
 
     @_catch_login_errors
-    async def async_play_tts_cloud_say(self, public_url, media_id, **kwargs):
+    async def async_play_tts_cloud_say(
+        self, media_type, public_url, media_id, **kwargs
+    ):
         file_name = media_id
         if media_source.is_media_source_id(media_id):
             media = await media_source.async_resolve_media(
@@ -1383,6 +1385,18 @@ class AlexaClient(MediaPlayerDevice, AlexaMedia):
             )
             file_name = media.url[media.url.rindex("/") : media.url.rindex(".")]
             media_id = async_process_play_media_url(self.hass, media.url)
+
+        if media_type == "music":
+            # Log and notify for Amazon restriction on streaming music
+            _LOGGER.warning(
+                "Sorry folks! Amazon doesn't allow streaming music like this. "
+                "Please take it up with them!"
+            )
+            await self.async_send_tts(
+                "Sorry folks! Amazon doesn't allow streaming music like this. "
+                "Please take it up with them!"
+            )
+            return
 
         if kwargs.get(ATTR_MEDIA_ANNOUNCE):
             input_file_path = self.hass.config.path(
@@ -1430,12 +1444,8 @@ class AlexaClient(MediaPlayerDevice, AlexaMedia):
                 f"<audio src='{public_url}local/alexa_tts{output_file_name}' />"
             )
         else:
-            await self.async_send_tts(
-                "To send TTS, please set Announce=true. Music can't be played this way."
-            )
-            _LOGGER.warning(
-                "To send TTS, please set Announce=true. Music can't be played this way."
-            )
+            await self.async_send_tts("To send TTS, please set Announce=true.")
+            _LOGGER.warning("To send TTS, please set Announce=true.")
 
     @_catch_login_errors
     async def async_play_media(self, media_type, media_id, enqueue=None, **kwargs):
@@ -1448,16 +1458,23 @@ class AlexaClient(MediaPlayerDevice, AlexaMedia):
             "options"
         ].get(CONF_PUBLIC_URL, DEFAULT_PUBLIC_URL)
         if media_type == "music":
-            if public_url:
-                await self.async_play_tts_cloud_say(public_url, media_id, **kwargs)
-            else:
-                await self.async_send_tts(
-                    "To send TTS, set public url in integration configuration"
-                )
+            if not public_url:
+                # Log and notify for missing public URL
                 _LOGGER.warning(
-                    "To send TTS, set public url in integration configuration"
-                    " Please see the alexa_media wiki for details."
-                    "https://github.com/alandtse/alexa_media_player/wiki/Configuration%3A-Notification-Component#use-the-notifyalexa_media-service"
+                    "To send TTS, please set the public URL in integration configuration."
+                )
+                await self.async_send_tts(
+                    "To send TTS, please set the public URL in integration configuration."
+                )
+            else:
+                # Log and notify for Amazon restriction on streaming music
+                _LOGGER.warning(
+                    "Sorry folks! Amazon doesn't allow streaming music like this. "
+                    "Please take it up with them!"
+                )
+                await self.async_send_tts(
+                    "Sorry folks! Amazon doesn't allow streaming music like this. "
+                    "Please take it up with them!"
                 )
         elif media_type == "sequence":
             _LOGGER.debug(


### PR DESCRIPTION
This clearly conveys to the users that the inability to stream music is not a problem with the integration or home assistant but instead something that Amazon doesn't allow. It also add media_type argument to the async_play_tts_cloud_say function to differentiate the error message for when it is a simple TTS message being sent or music