### PR TITLE
fix: TTS Speak Action in Home Assistant

### DIFF
--- a/custom_components/alexa_media/const.py
+++ b/custom_components/alexa_media/const.py
@@ -111,13 +111,12 @@ ATTR_MESSAGE = "message"
 ATTR_EMAIL = "email"
 ATTR_NUM_ENTRIES = "entries"
 STREAMING_ERROR_MESSAGE = (
-    "Sorry folks! Amazon doesn't allow streaming music like this. "
-    "Please take it up with them!"
+    "Sorry, direct music streaming isn't supported. "
+    "This limitation is set by Amazon, and not by Alexa-Media-Player, Music-Assistant, nor Home-Assistant."
 )
 PUBLIC_URL_ERROR_MESSAGE = (
     "To send TTS, please set the public URL in integration configuration."
 )
-ANNOUNCE_ERROR_MESSAGE = "To send TTS, please set Announce=true."
 STARTUP = f"""
 -------------------------------------------------------------------
 {DOMAIN}

--- a/custom_components/alexa_media/media_player.py
+++ b/custom_components/alexa_media/media_player.py
@@ -41,7 +41,6 @@ from . import (
 )
 from .alexa_media import AlexaMedia
 from .const import (
-    ANNOUNCE_ERROR_MESSAGE,
     DEPENDENT_ALEXA_COMPONENTS,
     MIN_TIME_BETWEEN_FORCED_SCANS,
     MIN_TIME_BETWEEN_SCANS,
@@ -1378,9 +1377,7 @@ class AlexaClient(MediaPlayerDevice, AlexaMedia):
             )
 
     @_catch_login_errors
-    async def async_play_tts_cloud_say(
-        self, media_type, public_url, media_id, **kwargs
-    ):
+    async def async_play_tts_cloud_say(self, public_url, media_id, **kwargs):
         file_name = media_id
         if media_source.is_media_source_id(media_id):
             media = await media_source.async_resolve_media(
@@ -1388,12 +1385,6 @@ class AlexaClient(MediaPlayerDevice, AlexaMedia):
             )
             file_name = media.url[media.url.rindex("/") : media.url.rindex(".")]
             media_id = async_process_play_media_url(self.hass, media.url)
-
-        if media_type == "music":
-            # Log and notify for Amazon restriction on streaming music
-            _LOGGER.warning(STREAMING_ERROR_MESSAGE)
-            await self.async_send_tts(STREAMING_ERROR_MESSAGE)
-            return
 
         if kwargs.get(ATTR_MEDIA_ANNOUNCE):
             input_file_path = self.hass.config.path(
@@ -1441,8 +1432,8 @@ class AlexaClient(MediaPlayerDevice, AlexaMedia):
                 f"<audio src='{public_url}local/alexa_tts{output_file_name}' />"
             )
         else:
-            await self.async_send_tts(ANNOUNCE_ERROR_MESSAGE)
-            _LOGGER.warning(ANNOUNCE_ERROR_MESSAGE)
+            await self.async_send_tts(STREAMING_ERROR_MESSAGE)
+            _LOGGER.warning(STREAMING_ERROR_MESSAGE)
 
     @_catch_login_errors
     async def async_play_media(self, media_type, media_id, enqueue=None, **kwargs):
@@ -1455,14 +1446,13 @@ class AlexaClient(MediaPlayerDevice, AlexaMedia):
             "options"
         ].get(CONF_PUBLIC_URL, DEFAULT_PUBLIC_URL)
         if media_type == "music":
-            if not public_url:
+            if public_url:
+                # Handle TTS playback
+                await self.async_play_tts_cloud_say(public_url, media_id, **kwargs)
+            else:
                 # Log and notify for missing public URL
                 _LOGGER.warning(PUBLIC_URL_ERROR_MESSAGE)
                 await self.async_send_tts(PUBLIC_URL_ERROR_MESSAGE)
-            else:
-                # Log and notify for Amazon restriction on streaming music
-                _LOGGER.warning(STREAMING_ERROR_MESSAGE)
-                await self.async_send_tts(STREAMING_ERROR_MESSAGE)
         elif media_type == "sequence":
             _LOGGER.debug(
                 "%s: %s:Running sequence %s with queue_delay %s",


### PR DESCRIPTION
Fixes the broken TTS action in Home Assistant that was broken in 5.0.3

TTS is defined as media_type music by the TTS component in Home Assistant which resulted in breaking the tts speak action. However, the async_speak function in the TTS component in HA always sets ATTR_MEDIA_ANNOUNCE to true in order to differentiate it from music (https://github.com/home-assistant/core/blob/b46392041f36cc932d0a12eb43af20ecfb7f25db/homeassistant/components/tts/__init__.py#L475) which is now properly implemented.