### PR TITLE
feat: readd support for Amazon devices

### DIFF
--- a/custom_components/alexa_media/alexa_entity.py
+++ b/custom_components/alexa_media/alexa_entity.py
@@ -89,6 +89,7 @@ def is_local(appliance: dict[str, Any]) -> bool:
     if (
         appliance.get("manufacturerName") == "Ledvance"
         or appliance.get("manufacturerName") == "Sengled"
+        or appliance.get("manufacturerName") == "Amazon"
     ):
         return not is_skill(appliance)
 

--- a/custom_components/alexa_media/alexa_entity.py
+++ b/custom_components/alexa_media/alexa_entity.py
@@ -88,7 +88,7 @@ def is_local(appliance: dict[str, Any]) -> bool:
     # Amazon devices are not local but bypassing the local check allows for control by the integration
     # There is probably a better way, but this works for now.
     manufacturerNames = ["Ledvance", "Sengled", "Amazon"]
-    if (appliance.get("manufacturerName") in manufacturerNames):
+    if appliance.get("manufacturerName") in manufacturerNames:
         return not is_skill(appliance)
 
     # Zigbee devices are guaranteed to be local and have a particular pattern of id

--- a/custom_components/alexa_media/alexa_entity.py
+++ b/custom_components/alexa_media/alexa_entity.py
@@ -87,10 +87,8 @@ def is_local(appliance: dict[str, Any]) -> bool:
     # Ledvance/Sengled bulbs connected via bluetooth are hard to detect as locally connected
     # Amazon devices are not local but bypassing the local check allows for control by the integration
     # There is probably a better way, but this works for now.
-    if (
-        manufacturerNames = ["Ledvance", "Sengled", "Amazon"]
-        appliance.get("manufacturerName") in manufacturerNames
-    ):
+    manufacturerNames = ["Ledvance", "Sengled", "Amazon"]
+    if (appliance.get("manufacturerName") in manufacturerNames):
         return not is_skill(appliance)
 
     # Zigbee devices are guaranteed to be local and have a particular pattern of id

--- a/custom_components/alexa_media/alexa_entity.py
+++ b/custom_components/alexa_media/alexa_entity.py
@@ -85,11 +85,11 @@ def is_local(appliance: dict[str, Any]) -> bool:
         return not is_skill(appliance)
 
     # Ledvance/Sengled bulbs connected via bluetooth are hard to detect as locally connected
+    # Amazon devices are not local but bypassing the local check allows for control by the integration
     # There is probably a better way, but this works for now.
     if (
-        appliance.get("manufacturerName") == "Ledvance"
-        or appliance.get("manufacturerName") == "Sengled"
-        or appliance.get("manufacturerName") == "Amazon"
+        manufacturerNames = ["Ledvance", "Sengled", "Amazon"]
+        appliance.get("manufacturerName") in manufacturerNames
     ):
         return not is_skill(appliance)
 


### PR DESCRIPTION
Reintroduces Amazon manufactured devices to be exposed by the integration.  This is especially useful for Amazon Smart Plugs which cannot be added to Home Assistant via any other means.