### PR TITLE
fix: restore Amazon air quality monitor entities

### DIFF
--- a/custom_components/alexa_media/alexa_entity.py
+++ b/custom_components/alexa_media/alexa_entity.py
@@ -108,7 +108,7 @@ def is_alexa_guard(appliance: dict[str, Any]) -> bool:
 def is_temperature_sensor(appliance: dict[str, Any]) -> bool:
     """Is the given appliance the temperature sensor of an Echo."""
     return (
-        is_local(appliance) 
+        is_local(appliance)
         and has_capability(appliance, "Alexa.TemperatureSensor", "temperature")
         and appliance["friendlyDescription"] != "Amazon Indoor Air Quality Monitor"
     )

--- a/custom_components/alexa_media/alexa_entity.py
+++ b/custom_components/alexa_media/alexa_entity.py
@@ -107,8 +107,10 @@ def is_alexa_guard(appliance: dict[str, Any]) -> bool:
 
 def is_temperature_sensor(appliance: dict[str, Any]) -> bool:
     """Is the given appliance the temperature sensor of an Echo."""
-    return is_local(appliance) and has_capability(
-        appliance, "Alexa.TemperatureSensor", "temperature"
+    return (
+        is_local(appliance) 
+        and has_capability(appliance, "Alexa.TemperatureSensor", "temperature")
+        and appliance["friendlyDescription"] != "Amazon Indoor Air Quality Monitor"
     )
 
 


### PR DESCRIPTION
Should fix #2756 but cannot confirm since I do not have an Amazon air quality monitor.