### PR TITLE
fix: Remove leading/trailing spaces from include_devices, exclude_devices

### DIFF
--- a/custom_components/alexa_media/config_flow.py
+++ b/custom_components/alexa_media/config_flow.py
@@ -960,10 +960,10 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                 if not user_input[CONF_PUBLIC_URL].endswith("/"):
                     user_input[CONF_PUBLIC_URL] = user_input[CONF_PUBLIC_URL] + "/"
             """Remove leading/trailing spaces in device strings"""
-           if CONF_INCLUDE_DEVICES in self._config_entry.data:
-               user_input[CONF_INCLUDE_DEVICES] = user_input[CONF_INCLUDE_DEVICES].strip()
-           if CONF_EXCLUDE_DEVICES in self._config_entry.data:
-               user_input[CONF_EXCLUDE_DEVICES] = user_input[CONF_EXCLUDE_DEVICES].strip()
+            if CONF_INCLUDE_DEVICES in self._config_entry.data:
+                user_input[CONF_INCLUDE_DEVICES] = user_input[CONF_INCLUDE_DEVICES].strip()
+            if CONF_EXCLUDE_DEVICES in self._config_entry.data:
+                user_input[CONF_EXCLUDE_DEVICES] = user_input[CONF_EXCLUDE_DEVICES].strip()
 
             self.hass.config_entries.async_update_entry(
                 self._config_entry, data=user_input, options=self._config_entry.options

--- a/custom_components/alexa_media/config_flow.py
+++ b/custom_components/alexa_media/config_flow.py
@@ -961,9 +961,13 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                     user_input[CONF_PUBLIC_URL] = user_input[CONF_PUBLIC_URL] + "/"
             """Remove leading/trailing spaces in device strings"""
             if CONF_INCLUDE_DEVICES in self._config_entry.data:
-                user_input[CONF_INCLUDE_DEVICES] = user_input[CONF_INCLUDE_DEVICES].strip()
+                user_input[CONF_INCLUDE_DEVICES] = user_input[
+                    CONF_INCLUDE_DEVICES
+                ].strip()
             if CONF_EXCLUDE_DEVICES in self._config_entry.data:
-                user_input[CONF_EXCLUDE_DEVICES] = user_input[CONF_EXCLUDE_DEVICES].strip()
+                user_input[CONF_EXCLUDE_DEVICES] = user_input[
+                    CONF_EXCLUDE_DEVICES
+                ].strip()
 
             self.hass.config_entries.async_update_entry(
                 self._config_entry, data=user_input, options=self._config_entry.options

--- a/custom_components/alexa_media/config_flow.py
+++ b/custom_components/alexa_media/config_flow.py
@@ -959,6 +959,11 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
             if CONF_PUBLIC_URL in self._config_entry.data:
                 if not user_input[CONF_PUBLIC_URL].endswith("/"):
                     user_input[CONF_PUBLIC_URL] = user_input[CONF_PUBLIC_URL] + "/"
+            """Remove leading/trailing spaces in device strings"""
+           if CONF_INCLUDE_DEVICES in self._config_entry.data:
+               user_input[CONF_INCLUDE_DEVICES] = user_input[CONF_INCLUDE_DEVICES].strip()
+           if CONF_EXCLUDE_DEVICES in self._config_entry.data:
+               user_input[CONF_EXCLUDE_DEVICES] = user_input[CONF_EXCLUDE_DEVICES].strip()
 
             self.hass.config_entries.async_update_entry(
                 self._config_entry, data=user_input, options=self._config_entry.options


### PR DESCRIPTION
This allows users to enter a space to clear the previous entry and we need to change the string from " " to "".

This fixes issue #2556 #2751 