### PR TITLE
feat: add new attribute: `previous_volume`

### DIFF
--- a/custom_components/alexa_media/media_player.py
+++ b/custom_components/alexa_media/media_player.py
@@ -1131,7 +1131,7 @@ class AlexaClient(MediaPlayerDevice, AlexaMedia):
         if not self.available:
             return
 
-        # Save the curent volume level before we change it
+        # Save the current volume level before we change it
         _LOGGER.debug("Saving previous volume level: %s", self.volume_level)
         self._previous_volume = self.volume_level
 

--- a/custom_components/alexa_media/media_player.py
+++ b/custom_components/alexa_media/media_player.py
@@ -474,7 +474,7 @@ class AlexaClient(MediaPlayerDevice, AlexaMedia):
                     already_refreshed = True
                 elif "volumeSetting" in player_state:
                     _LOGGER.debug(
-                        '%s: %s volume updated: %s',
+                        "%s: %s volume updated: %s",
                         hide_email(self._login.email),
                         self.name,
                         player_state["volumeSetting"],

--- a/custom_components/alexa_media/media_player.py
+++ b/custom_components/alexa_media/media_player.py
@@ -245,6 +245,7 @@ class AlexaClient(MediaPlayerDevice, AlexaMedia):
         self._media_is_muted = None
         self._media_vol_level = None
         self._previous_volume = None
+        self._saved_volume = None
         self._source = None
         self._source_list = []
         self._connected_bluetooth = None
@@ -473,7 +474,7 @@ class AlexaClient(MediaPlayerDevice, AlexaMedia):
                     already_refreshed = True
                 elif "volumeSetting" in player_state:
                     _LOGGER.debug(
-                        "%s: %s volume updated: %s",
+                        "%s: %s volume updated: player_state[\"volumeSetting\"]: %s",
                         hide_email(self._login.email),
                         self.name,
                         player_state["volumeSetting"],
@@ -1129,14 +1130,23 @@ class AlexaClient(MediaPlayerDevice, AlexaMedia):
         """Set volume level, range 0..1."""
         if not self.available:
             return
+        
+        # Save the curent volume level before we change it
+        _LOGGER.debug("Saving previous volume level: %s", self.volume_level)
+        self._previous_volume = self.volume_level
+        
+        # Change the volume level on the device
         if self.hass:
             self.hass.async_create_task(self.alexa_api.set_volume(volume))
         else:
             await self.alexa_api.set_volume(volume)
         self._media_vol_level = volume
+
+        # Let http2push update the new volume level
         if not (
             self.hass.data[DATA_ALEXAMEDIA]["accounts"][self._login.email]["http2"]
         ):
+            # Otherwise we do it ourselves
             await self.async_update()
 
     @property
@@ -1164,19 +1174,19 @@ class AlexaClient(MediaPlayerDevice, AlexaMedia):
 
         self._media_is_muted = mute
         if mute:
-            self._previous_volume = self.volume_level
+            self._saved_volume = self.volume_level
             if self.hass:
                 self.hass.async_create_task(self.alexa_api.set_volume(0))
             else:
                 await self.alexa_api.set_volume(0)
         else:
-            if self._previous_volume is not None:
+            if self._saved_volume is not None:
                 if self.hass:
                     self.hass.async_create_task(
-                        self.alexa_api.set_volume(self._previous_volume)
+                        self.alexa_api.set_volume(self._saved_volume)
                     )
                 else:
-                    await self.alexa_api.set_volume(self._previous_volume)
+                    await self.alexa_api.set_volume(self._saved_volume)
             else:
                 if self.hass:
                     self.hass.async_create_task(self.alexa_api.set_volume(50))
@@ -1620,6 +1630,7 @@ class AlexaClient(MediaPlayerDevice, AlexaMedia):
             "last_called_summary": self._last_called_summary,
             "connected_bluetooth": self._connected_bluetooth,
             "bluetooth_list": self._bluetooth_list,
+            "previous_volume": self._previous_volume,
         }
         return attr
 

--- a/custom_components/alexa_media/media_player.py
+++ b/custom_components/alexa_media/media_player.py
@@ -474,7 +474,7 @@ class AlexaClient(MediaPlayerDevice, AlexaMedia):
                     already_refreshed = True
                 elif "volumeSetting" in player_state:
                     _LOGGER.debug(
-                        "%s: %s volume updated: player_state[\"volumeSetting\"]: %s",
+                        '%s: %s volume updated: player_state["volumeSetting"]: %s',
                         hide_email(self._login.email),
                         self.name,
                         player_state["volumeSetting"],
@@ -1130,11 +1130,11 @@ class AlexaClient(MediaPlayerDevice, AlexaMedia):
         """Set volume level, range 0..1."""
         if not self.available:
             return
-        
+
         # Save the curent volume level before we change it
         _LOGGER.debug("Saving previous volume level: %s", self.volume_level)
         self._previous_volume = self.volume_level
-        
+
         # Change the volume level on the device
         if self.hass:
             self.hass.async_create_task(self.alexa_api.set_volume(volume))

--- a/custom_components/alexa_media/media_player.py
+++ b/custom_components/alexa_media/media_player.py
@@ -474,7 +474,7 @@ class AlexaClient(MediaPlayerDevice, AlexaMedia):
                     already_refreshed = True
                 elif "volumeSetting" in player_state:
                     _LOGGER.debug(
-                        '%s: %s volume updated: player_state["volumeSetting"]: %s',
+                        '%s: %s volume updated: %s',
                         hide_email(self._login.email),
                         self.name,
                         player_state["volumeSetting"],


### PR DESCRIPTION
This saves the current volume level in new attribute `previous_volume` before changing the volume level.

See discussion #2765 