### PR TITLE
perf: select the same URL for NotifyNowPlayingUpdated as for get_state()

### DIFF
--- a/custom_components/alexa_media/media_player.py
+++ b/custom_components/alexa_media/media_player.py
@@ -750,7 +750,7 @@ class AlexaClient(MediaPlayerDevice, AlexaMedia):
                 )
                 if self._media_image_url is None:
                     self._media_image_url = (
-                        self._session.get("mainArt", {}).get("largeUrl")
+                        self._session.get("mainArt", {}).get("fullUrl")
                         if self._session.get("mainArt")
                         else None
                     )


### PR DESCRIPTION
Selecting the same URL prevents unnecessary HTTP requests.