### PR TITLE
fix: (previous|next)_track handling

### DIFF
--- a/custom_components/alexa_media/media_player.py
+++ b/custom_components/alexa_media/media_player.py
@@ -420,7 +420,9 @@ class AlexaClient(MediaPlayerDevice, AlexaMedia):
                 if player_info.get("mainArt", {}).get("url") is None:
                     if not player_info.get("mainArt"):
                         player_info["mainArt"] = {}
-                    player_info["mainArt"]["url"] = player_info["mainArt"].get("fullUrl")
+                    player_info["mainArt"]["url"] = player_info["mainArt"].get(
+                        "fullUrl"
+                    )
                 player_info["last_update"] = util.utcnow()
                 _LOGGER.debug(
                     f"Match media_id: {media_id} in waiting_media_id:{self._waiting_media_id} , player_info: {player_info}"
@@ -711,7 +713,7 @@ class AlexaClient(MediaPlayerDevice, AlexaMedia):
                     if self._player_info:
                         session = {"playerInfo": self._player_info.copy()}
                     else:
-                        session = await self._api_get_state(no_throttle = no_throttle)
+                        session = await self._api_get_state(no_throttle=no_throttle)
                         if session is None:
                             # _LOGGER.warning(
                             #     "%s: Can't get session state by alexa_api.get_state() of %s. Probably a re-login occurred, so ignore it this time.",
@@ -1116,7 +1118,11 @@ class AlexaClient(MediaPlayerDevice, AlexaMedia):
     @property
     def media_position_updated_at(self):
         """When was the position of the current playing media valid."""
-        return self._player_info["last_update"] if self._player_info and self._player_info.get("last_update") else self._last_update
+        return (
+            self._player_info["last_update"]
+            if self._player_info and self._player_info.get("last_update")
+            else self._last_update
+        )
 
     @property
     def media_image_url(self) -> Optional[str]:

--- a/custom_components/alexa_media/media_player.py
+++ b/custom_components/alexa_media/media_player.py
@@ -357,7 +357,7 @@ class AlexaClient(MediaPlayerDevice, AlexaMedia):
             self._player_info = None
             start = util.dt.as_timestamp(util.utcnow())
             while (
-                not self._player_info
+                self._player_info is None
                 and media_id == self._waiting_media_id
                 and (start + timeout >= util.dt.as_timestamp(util.utcnow()))
             ):
@@ -399,7 +399,7 @@ class AlexaClient(MediaPlayerDevice, AlexaMedia):
                 event.get("push_activity", {}).get("key", {}).get("serialNumber")
             )
         elif "now_playing" in event:
-            player_info = media_id = (
+            player_info = (
                 event.get("now_playing", {})
                 .get("update", {})
                 .get("update", {})
@@ -407,12 +407,25 @@ class AlexaClient(MediaPlayerDevice, AlexaMedia):
             )
             media_id = player_info.get("mediaId")
             if self._waiting_media_id and media_id in self._waiting_media_id:
+                if player_info.get("playerState"):
+                    player_info["state"] = player_info["playerState"]
+                if player_info.get("progress", {}).get("mediaProgress"):
+                    player_info["progress"]["mediaProgress"] = int(
+                        player_info["progress"]["mediaProgress"] / 1000
+                    )
+                if player_info.get("progress", {}).get("mediaLength"):
+                    player_info["progress"]["mediaLength"] = int(
+                        player_info["progress"]["mediaLength"] / 1000
+                    )
+                if player_info.get("mainArt", {}).get("url") is None:
+                    if not player_info.get("mainArt"):
+                        player_info["mainArt"] = {}
+                    player_info["mainArt"]["url"] = player_info["mainArt"].get("fullUrl")
+                player_info["last_update"] = util.utcnow()
                 _LOGGER.debug(
                     f"Match media_id: {media_id} in waiting_media_id:{self._waiting_media_id} , player_info: {player_info}"
                 )
-                self._waiting_media_id = None
                 self._player_info = player_info
-
         if not event_serial:
             return
         if event_serial == self.device_serial_number:
@@ -490,7 +503,9 @@ class AlexaClient(MediaPlayerDevice, AlexaMedia):
                     if media_id:
                         self._waiting_media_id = media_id
                         await _wait_player_info(media_id)
-                    if self._player_info is None:
+                        if self._waiting_media_id != media_id:
+                            return
+                    if not media_id and self._player_info is None:
                         # allow delay before trying to refresh to avoid http 400 errors
                         await asyncio.sleep(2)
                     await self.async_update()
@@ -585,8 +600,11 @@ class AlexaClient(MediaPlayerDevice, AlexaMedia):
         self._customer_name = auth["customerName"]
 
     @util.Throttle(MIN_TIME_BETWEEN_SCANS, MIN_TIME_BETWEEN_FORCED_SCANS)
+    async def _api_get_state(self):
+        return await self.alexa_api.get_state()
+
     @_catch_login_errors
-    async def refresh(self, device=None, skip_api: bool = False):
+    async def refresh(self, device=None, skip_api: bool = False, no_throttle=False):
         # pylint: disable=too-many-branches,too-many-statements
         """Refresh device data.
 
@@ -691,22 +709,9 @@ class AlexaClient(MediaPlayerDevice, AlexaMedia):
                 else:
                     self._playing_parent = None
                     if self._player_info:
-                        if self._player_info.get("playerState"):
-                            self._player_info["state"] = self._player_info[
-                                "playerState"
-                            ]
-                        if self._player_info.get("progress", {}).get("mediaProgress"):
-                            self._player_info["progress"]["mediaProgress"] = int(
-                                self._player_info["progress"]["mediaProgress"] / 1000
-                            )
-                        if self._player_info.get("progress", {}).get("mediaLength"):
-                            self._player_info["progress"]["mediaLength"] = int(
-                                self._player_info["progress"]["mediaLength"] / 1000
-                            )
                         session = {"playerInfo": self._player_info.copy()}
-                        self._player_info = None
                     else:
-                        session = await self.alexa_api.get_state()
+                        session = await self._api_get_state(no_throttle = no_throttle)
                         if session is None:
                             # _LOGGER.warning(
                             #     "%s: Can't get session state by alexa_api.get_state() of %s. Probably a re-login occurred, so ignore it this time.",
@@ -716,9 +721,8 @@ class AlexaClient(MediaPlayerDevice, AlexaMedia):
                             return
         self._clear_media_details()
         # update the session if it exists
-        self._session = session if session else None
-        if self._session and self._session.get("playerInfo"):
-            self._session = self._session["playerInfo"]
+        self._session = session.get("playerInfo") if session else None
+        if self._session:
             if self._session.get("transport"):
                 self._shuffle = (
                     self._session["transport"]["shuffle"] == "SELECTED"
@@ -748,12 +752,6 @@ class AlexaClient(MediaPlayerDevice, AlexaMedia):
                     if self._session.get("mainArt")
                     else None
                 )
-                if self._media_image_url is None:
-                    self._media_image_url = (
-                        self._session.get("mainArt", {}).get("largeUrl")
-                        if self._session.get("mainArt")
-                        else None
-                    )
                 self._media_pos = (
                     self._session.get("progress", {}).get("mediaProgress")
                     if self._session.get("progress")
@@ -1118,7 +1116,7 @@ class AlexaClient(MediaPlayerDevice, AlexaMedia):
     @property
     def media_position_updated_at(self):
         """When was the position of the current playing media valid."""
-        return self._last_update
+        return self._player_info["last_update"] if self._player_info and self._player_info.get("last_update") else self._last_update
 
     @property
     def media_image_url(self) -> Optional[str]:


### PR DESCRIPTION
This is related to #2827

- Fixed an issue where the throttle was unnecessarily applied when `(previous|next)_track` occurred, preventing proper processing.
- Processed `player_info` acquisition processing by "mediaReferenceId" more strictly.
- Suppressed unnecessary `get_state()` calls.