### PR TITLE
fix: Ensure Alexa-Compatible MP3 Output Using FFmpeg Flag

### DIFF
--- a/custom_components/alexa_media/media_player.py
+++ b/custom_components/alexa_media/media_player.py
@@ -1542,8 +1542,8 @@ class AlexaClient(MediaPlayerDevice, AlexaMedia):
                     "48k",
                     "-ar",
                     "24000",
-                    "-write_xing"
-                    "0"
+                    "-write_xing",
+                    "0",
                     output_file_path,
                 ]
                 if subprocess.run(command, check=True).returncode != 0:

--- a/custom_components/alexa_media/media_player.py
+++ b/custom_components/alexa_media/media_player.py
@@ -1542,6 +1542,8 @@ class AlexaClient(MediaPlayerDevice, AlexaMedia):
                     "48k",
                     "-ar",
                     "24000",
+                    "-write_xing"
+                    "0"
                     output_file_path,
                 ]
                 if subprocess.run(command, check=True).returncode != 0:


### PR DESCRIPTION
According to the [Alexa SSML documentation](https://developer.amazon.com/en-US/docs/alexa/custom-skills/speech-synthesis-markup-language-ssml-reference.html#h3_converting_mp3), the `-write_xing 0` flag must be used when generating MP3 files to ensure compatibility with Alexa.

This change adds the necessary FFmpeg flag during MP3 creation to produce files that meet Alexa's playback requirements.