### PR TITLE
fix: Remove deprecated call to get_network_details

### DIFF
--- a/custom_components/alexa_media/__init__.py
+++ b/custom_components/alexa_media/__init__.py
@@ -433,9 +433,7 @@ async def setup_alexa(hass, config_entry, login_obj: AlexaLogin):
         ].values()
         auth_info = hass.data[DATA_ALEXAMEDIA]["accounts"][email].get("auth_info")
         new_devices = hass.data[DATA_ALEXAMEDIA]["accounts"][email]["new_devices"]
-        should_get_network = hass.data[DATA_ALEXAMEDIA]["accounts"][email][
-            "should_get_network"
-        ]
+        should_get_network = False  # get_network_details is deprecated
         extended_entity_discovery = hass.data[DATA_ALEXAMEDIA]["accounts"][email][
             "options"
         ].get(CONF_EXTENDED_ENTITY_DISCOVERY)
@@ -486,9 +484,6 @@ async def setup_alexa(hass, config_entry, login_obj: AlexaLogin):
         if entities_to_monitor:
             tasks.append(get_entity_data(login_obj, list(entities_to_monitor)))
 
-        if should_get_network:
-            tasks.append(AlexaAPI.get_network_details(login_obj))
-
         try:
             # Note: asyncio.TimeoutError and aiohttp.ClientError are already
             # handled by the data update coordinator.
@@ -503,24 +498,7 @@ async def setup_alexa(hass, config_entry, login_obj: AlexaLogin):
 
                 if should_get_network:
                     _LOGGER.debug(
-                        "Alexa entities have been loaded. Prepared for discovery."
-                    )
-                    alexa_entities = parse_alexa_entities(optional_task_results.pop())
-                    hass.data[DATA_ALEXAMEDIA]["accounts"][email]["devices"].update(
-                        alexa_entities
-                    )
-                    hass.data[DATA_ALEXAMEDIA]["accounts"][email][
-                        "should_get_network"
-                    ] = False
-
-                    # First run is a special case. Get the state of all entities(including disabled)
-                    # This ensures all entities have state during startup without needing to request coordinator refresh
-                    for type_of_entity, entities in alexa_entities.items():
-                        if type_of_entity == "guard" or extended_entity_discovery:
-                            for entity in entities:
-                                entities_to_monitor.add(entity.get("id"))
-                    entity_state = await get_entity_data(
-                        login_obj, list(entities_to_monitor)
+                        "AlexaAPI.get_network_details is deprecated and no longer called. Network details will not be updated."
                     )
                 elif entities_to_monitor:
                     entity_state = optional_task_results.pop()

--- a/custom_components/alexa_media/__init__.py
+++ b/custom_components/alexa_media/__init__.py
@@ -496,11 +496,7 @@ async def setup_alexa(hass, config_entry, login_obj: AlexaLogin):
                     *optional_task_results,
                 ) = await asyncio.gather(*tasks)
 
-                if should_get_network:
-                    _LOGGER.debug(
-                        "AlexaAPI.get_network_details is deprecated and no longer called. Network details will not be updated."
-                    )
-                elif entities_to_monitor:
+                if entities_to_monitor:
                     entity_state = optional_task_results.pop()
 
                 if new_devices:


### PR DESCRIPTION
Should fix #2940, #2932, #2934, and #2942

This can be a stop gap solution until the API is brought back online (which I doubt it will be).  With this we are losing access to the "Include devices connected via Echo" but the Echo devices should be working again.

I've only performed some basic tests so other functions may also be impacted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Removed deprecated network details retrieval from the data update process to streamline updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->