### PR TITLE
fix: replace deprecated MediaPlayerState.STANDBY

### DIFF
--- a/custom_components/alexa_media/media_player.py
+++ b/custom_components/alexa_media/media_player.py
@@ -1021,7 +1021,7 @@ class AlexaClient(MediaPlayerDevice, AlexaMedia):
             return MediaPlayerState.PAUSED
         if self._media_player_state == "IDLE":
             return MediaPlayerState.IDLE
-        return MediaPlayerState.STANDBY
+        return MediaPlayerState.OFF
 
     def update(self):
         """Get the latest details on a media player synchronously."""
@@ -1143,7 +1143,7 @@ class AlexaClient(MediaPlayerDevice, AlexaMedia):
         """Return the content type of current playing media."""
         if self.state in [MediaPlayerState.PLAYING, MediaPlayerState.PAUSED]:
             return MediaType.MUSIC
-        return MediaPlayerState.STANDBY
+        return MediaPlayerState.OFF
 
     @property
     def media_artist(self):

--- a/custom_components/alexa_media/media_player.py
+++ b/custom_components/alexa_media/media_player.py
@@ -1021,7 +1021,7 @@ class AlexaClient(MediaPlayerDevice, AlexaMedia):
             return MediaPlayerState.PAUSED
         if self._media_player_state == "IDLE":
             return MediaPlayerState.IDLE
-        return MediaPlayerState.OFF
+        return MediaPlayerState.IDLE
 
     def update(self):
         """Get the latest details on a media player synchronously."""
@@ -1143,7 +1143,7 @@ class AlexaClient(MediaPlayerDevice, AlexaMedia):
         """Return the content type of current playing media."""
         if self.state in [MediaPlayerState.PLAYING, MediaPlayerState.PAUSED]:
             return MediaType.MUSIC
-        return MediaPlayerState.OFF
+        return MediaPlayerState.IDLE
 
     @property
     def media_artist(self):


### PR DESCRIPTION
The deprecated enum member MediaPlayerState.STANDBY was used from alexa_media. It will be removed in HA Core 2026.8.0. Use MediaPlayerState.OFF or MediaPlayerState.IDLE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated media player behavior to show as "Off" instead of "Standby" when not active or playing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->