### PR TITLE
fix: Model ID for Echo Dot (Gen4)

### DIFF
--- a/custom_components/alexa_media/const.py
+++ b/custom_components/alexa_media/const.py
@@ -230,7 +230,7 @@ MODEL_IDS = {
     "A2RU4B77X9R9NZ": "Echo Link Amp",
     "A2TF17PFR55MTB": "Alexa Mobile Voice Android",
     "A2TTLILJHVNI9X": "LG TV",
-    "A2U21SRK4QGSE1": "Echo Dot Clock (Gen4)",
+    "A2U21SRK4QGSE1": "Echo Dot (Gen4)",
     "A2UONLFQW0PADH": "Echo Show 8 (Gen3)",
     "A2V9UEGZ82H4KZ": "Fire Tablet HD 10",
     "A2VAXZ7UNGY4ZH": "Wyze Headphones",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the displayed model name for an Echo Dot (Gen4) device that was previously labeled as “Echo Dot Clock (Gen4)”.
  * Ensures the correct product name appears in the UI, reducing confusion between the standard and clock variants.
  * No behavioral or functional changes; this is a label update only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->