### PR TITLE
feat: add entity translations for sensors and switches

### DIFF
--- a/custom_components/alexa_media/sensor.py
+++ b/custom_components/alexa_media/sensor.py
@@ -338,6 +338,9 @@ def lookup_device_info(account_dict, device_serial):
 class TemperatureSensor(SensorEntity, CoordinatorEntity):
     """A temperature sensor reported by an Echo or an AIAQM endpoint."""
 
+    _attr_has_entity_name = True
+    _attr_translation_key = "temperature"
+
     def __init__(
         self,
         coordinator,
@@ -352,10 +355,10 @@ class TemperatureSensor(SensorEntity, CoordinatorEntity):
         super().__init__(coordinator)
         self._debug = bool(debug)
         self.alexa_entity_id = entity_id
+        self._device_name = name
         # Need to append "+temperature" because the Alexa entityId is for a physical device
         # and a single physical device can have multiple HA entities
         self._attr_unique_id = entity_id + "_temperature"
-        self._attr_name = name + " Temperature"
         self._attr_device_class = SensorDeviceClass.TEMPERATURE
         self._attr_state_class = SensorStateClass.MEASUREMENT
         value_and_scale: Optional[dict] = parse_temperature_from_coordinator(
@@ -387,7 +390,7 @@ class TemperatureSensor(SensorEntity, CoordinatorEntity):
         else:
             self._attr_device_info = None
 
-        _LOGGER.debug("Coordinator init: %s", self._attr_name)
+        _LOGGER.debug("Coordinator init: %s Temperature", self._device_name)
 
     @callback
     def _handle_coordinator_update(self) -> None:
@@ -404,8 +407,8 @@ class TemperatureSensor(SensorEntity, CoordinatorEntity):
         )
         unit_str = self._attr_native_unit_of_measurement or ""
         _LOGGER.debug(
-            "Coordinator update: %s: %s%s",
-            self._attr_name,
+            "Coordinator update: %s Temperature: %s%s",
+            self._device_name,
             value_str,
             unit_str,
         )
@@ -431,8 +434,20 @@ class TemperatureSensor(SensorEntity, CoordinatorEntity):
         return None
 
 
+# Mapping from Alexa AirQuality sensor types to translation keys
+AIR_QUALITY_TRANSLATION_KEYS = {
+    "Alexa.AirQuality.CarbonMonoxide": "air_quality_carbon_monoxide",
+    "Alexa.AirQuality.Humidity": "air_quality_humidity",
+    "Alexa.AirQuality.IndoorAirQuality": "air_quality_indoor_air_quality",
+    "Alexa.AirQuality.ParticulateMatter": "air_quality_particulate_matter",
+    "Alexa.AirQuality.VolatileOrganicCompounds": "air_quality_volatile_organic_compounds",
+}
+
+
 class AirQualitySensor(SensorEntity, CoordinatorEntity):
     """An air quality sensor reported by an Amazon indoor air quality monitor."""
+
+    _attr_has_entity_name = True
 
     def __init__(
         self,
@@ -450,13 +465,17 @@ class AirQualitySensor(SensorEntity, CoordinatorEntity):
         super().__init__(coordinator)
         self._debug = bool(debug)
         self.alexa_entity_id = entity_id
-        self._sensor_name = sensor_name
-        # tidy up name
-        self._sensor_name = self._sensor_name.replace("Alexa.AirQuality.", "")
+        self._device_name = name
+        self._sensor_type = sensor_name
+        # Set translation key based on sensor type
+        self._attr_translation_key = AIR_QUALITY_TRANSLATION_KEYS.get(
+            sensor_name, "air_quality"
+        )
+        # tidy up name for unique_id and logging
+        self._sensor_name = sensor_name.replace("Alexa.AirQuality.", "")
         self._sensor_name = "".join(
             " " + char if char.isupper() else char.strip() for char in self._sensor_name
         ).strip()
-        self._attr_name = name + " " + self._sensor_name
         self._attr_device_class = ALEXA_AIR_QUALITY_DEVICE_CLASS.get(sensor_name)
         self._attr_state_class = SensorStateClass.MEASUREMENT
         self._attr_native_value: Optional[int | float | str] = (
@@ -490,7 +509,7 @@ class AirQualitySensor(SensorEntity, CoordinatorEntity):
             self._attr_device_info = None
 
         self._instance = instance
-        _LOGGER.debug("Coordinator init: %s", self._attr_name)
+        _LOGGER.debug("Coordinator init: %s %s", self._device_name, self._sensor_name)
 
     @callback
     def _handle_coordinator_update(self) -> None:
@@ -503,13 +522,14 @@ class AirQualitySensor(SensorEntity, CoordinatorEntity):
         )
         unit_str = self._attr_native_unit_of_measurement or ""
         fmt = (
-            "Coordinator update: %s: %s%s"
+            "Coordinator update: %s %s: %s%s"
             if unit_str in ("", "%")
-            else "Coordinator update: %s: %s %s"
+            else "Coordinator update: %s %s: %s %s"
         )
         _LOGGER.debug(
             fmt,
-            self._attr_name,
+            self._device_name,
+            self._sensor_name,
             value_str,
             unit_str,
         )
@@ -519,7 +539,17 @@ class AirQualitySensor(SensorEntity, CoordinatorEntity):
 class AlexaMediaNotificationSensor(SensorEntity):
     """Representation of Alexa Media sensors."""
 
+    _attr_has_entity_name = True
+    _attr_native_unit_of_measurement = None
     _unrecorded_attributes = frozenset({"brief", "sorted_active", "sorted_all"})
+
+    @property
+    def _unit_of_measurement_translation_key(self) -> str | None:
+        """Return None to prevent unit translation lookup before platform registration."""
+        # Override to prevent ValueError when translation_key is set
+        # but entity is not yet added to platform (platform_data is None)
+        # Timestamp sensors don't have units, so always return None
+        return None
     _LABEL_KEY_MAP: ClassVar[dict[str, str]] = {
         "Alarm": "alarmLabel",
         "Timer": "timerLabel",
@@ -542,12 +572,10 @@ class AlexaMediaNotificationSensor(SensorEntity):
         self._attr_device_class = SensorDeviceClass.TIMESTAMP
         self._attr_state_class = None
         self._attr_native_value: Optional[datetime.datetime] = None
-        self._attr_name = f"{client.name} {name}"
         self._attr_unique_id = f"{client.unique_id}_{name}"
         self._attr_icon = icon
         self._attr_device_info = {
             "identifiers": {(ALEXA_DOMAIN, client.unique_id)},
-            "via_device": (ALEXA_DOMAIN, client.unique_id),
         }
         self._attr_assumed_state = client.assumed_state
         self._attr_available = client.available
@@ -979,6 +1007,8 @@ class AlexaMediaNotificationSensor(SensorEntity):
 class AlarmSensor(AlexaMediaNotificationSensor):
     """Representation of a Alexa Alarm sensor."""
 
+    _attr_translation_key = "next_alarm"
+
     def __init__(self, client, n_json, account, debug: bool = False):
         """Initialize the Alexa sensor."""
         # Class info
@@ -988,7 +1018,7 @@ class AlarmSensor(AlexaMediaNotificationSensor):
             n_json,
             "date_time",
             account,
-            f"next {self._type}",
+            "next_alarm",
             "mdi:alarm",
             debug=debug,
         )
@@ -996,6 +1026,8 @@ class AlarmSensor(AlexaMediaNotificationSensor):
 
 class TimerSensor(AlexaMediaNotificationSensor):
     """Representation of a Alexa Timer sensor."""
+
+    _attr_translation_key = "next_timer"
 
     def __init__(self, client, n_json, account, debug: bool = False):
         """Initialize the Alexa sensor."""
@@ -1006,7 +1038,7 @@ class TimerSensor(AlexaMediaNotificationSensor):
             n_json,
             "remainingTime",
             account,
-            f"next {self._type}",
+            "next_timer",
             (
                 "mdi:timer-outline"
                 if (version.parse(HA_VERSION) >= version.parse("0.113.0"))
@@ -1058,6 +1090,8 @@ class TimerSensor(AlexaMediaNotificationSensor):
 class ReminderSensor(AlexaMediaNotificationSensor):
     """Representation of a Alexa Reminder sensor."""
 
+    _attr_translation_key = "next_reminder"
+
     def __init__(self, client, n_json, account, debug: bool = False):
         """Initialize the Alexa sensor."""
         self._type = "Reminder"
@@ -1066,7 +1100,7 @@ class ReminderSensor(AlexaMediaNotificationSensor):
             n_json,
             "alarmTime",
             account,
-            f"next {self._type}",
+            "next_reminder",
             "mdi:reminder",
             debug=debug,
         )

--- a/custom_components/alexa_media/sensor.py
+++ b/custom_components/alexa_media/sensor.py
@@ -550,6 +550,7 @@ class AlexaMediaNotificationSensor(SensorEntity):
         # but entity is not yet added to platform (platform_data is None)
         # Timestamp sensors don't have units, so always return None
         return None
+
     _LABEL_KEY_MAP: ClassVar[dict[str, str]] = {
         "Alarm": "alarmLabel",
         "Timer": "timerLabel",

--- a/custom_components/alexa_media/strings.json
+++ b/custom_components/alexa_media/strings.json
@@ -127,6 +127,51 @@
       }
     }
   },
+  "entity": {
+    "switch": {
+      "do_not_disturb": {
+        "name": "Do not disturb"
+      },
+      "shuffle": {
+        "name": "Shuffle"
+      },
+      "repeat": {
+        "name": "Repeat"
+      }
+    },
+    "sensor": {
+      "temperature": {
+        "name": "Temperature"
+      },
+      "air_quality": {
+        "name": "Air quality"
+      },
+      "air_quality_carbon_monoxide": {
+        "name": "Carbon monoxide"
+      },
+      "air_quality_humidity": {
+        "name": "Humidity"
+      },
+      "air_quality_indoor_air_quality": {
+        "name": "Indoor air quality"
+      },
+      "air_quality_particulate_matter": {
+        "name": "Particulate matter"
+      },
+      "air_quality_volatile_organic_compounds": {
+        "name": "Volatile organic compounds"
+      },
+      "next_alarm": {
+        "name": "Next alarm"
+      },
+      "next_timer": {
+        "name": "Next timer"
+      },
+      "next_reminder": {
+        "name": "Next reminder"
+      }
+    }
+  },
   "issues": {
     "deprecated_yaml_configuration": {
       "title": "YAML configuration is deprecated",

--- a/custom_components/alexa_media/switch.py
+++ b/custom_components/alexa_media/switch.py
@@ -171,17 +171,19 @@ async def async_unload_entry(hass, entry) -> bool:
 class AlexaMediaSwitch(SwitchDevice, AlexaMedia):
     """Representation of a Alexa Media switch."""
 
+    _attr_has_entity_name = True
+
     def __init__(
         self,
         client,
         switch_property: str,
         switch_function: str,
-        name="Alexa",
+        unique_id_suffix: str = "switch",
     ):
         """Initialize the Alexa Switch device."""
         # Class info
         self._client = client
-        self._name = name
+        self._unique_id_suffix = unique_id_suffix
         self._switch_property = switch_property
         self._switch_function = switch_function
         super().__init__(client, client._login)
@@ -244,7 +246,7 @@ class AlexaMediaSwitch(SwitchDevice, AlexaMedia):
             _LOGGER.debug(
                 "Requesting update of %s due to %s switch to %s",
                 self._client,
-                self._name,
+                self._unique_id_suffix,
                 state,
             )
             await self._client.async_update()
@@ -278,12 +280,7 @@ class AlexaMediaSwitch(SwitchDevice, AlexaMedia):
     @property
     def unique_id(self):
         """Return the unique ID."""
-        return self._client.unique_id + "_" + self._name
-
-    @property
-    def name(self):
-        """Return the name of the switch."""
-        return f"{self._client.name} {self._name} switch"
+        return self._client.unique_id + "_" + self._unique_id_suffix
 
     @property
     def device_class(self):
@@ -333,6 +330,8 @@ class AlexaMediaSwitch(SwitchDevice, AlexaMedia):
 class DNDSwitch(AlexaMediaSwitch):
     """Representation of a Alexa Media Do Not Disturb switch."""
 
+    _attr_translation_key = "do_not_disturb"
+
     def __init__(self, client):
         """Initialize the Alexa Switch."""
         # Class info
@@ -340,7 +339,7 @@ class DNDSwitch(AlexaMediaSwitch):
             client,
             "dnd_state",
             "set_dnd_state",
-            "do not disturb",
+            "do_not_disturb",
         )
 
     @property
@@ -379,6 +378,8 @@ class DNDSwitch(AlexaMediaSwitch):
 class ShuffleSwitch(AlexaMediaSwitch):
     """Representation of a Alexa Media Shuffle switch."""
 
+    _attr_translation_key = "shuffle"
+
     def __init__(self, client):
         """Initialize the Alexa Switch."""
         # Class info
@@ -397,6 +398,8 @@ class ShuffleSwitch(AlexaMediaSwitch):
 
 class RepeatSwitch(AlexaMediaSwitch):
     """Representation of a Alexa Media Repeat switch."""
+
+    _attr_translation_key = "repeat"
 
     def __init__(self, client):
         """Initialize the Alexa Switch."""

--- a/custom_components/alexa_media/translations/en.json
+++ b/custom_components/alexa_media/translations/en.json
@@ -53,6 +53,51 @@
       }
     }
   },
+  "entity": {
+    "switch": {
+      "do_not_disturb": {
+        "name": "Do not disturb"
+      },
+      "repeat": {
+        "name": "Repeat"
+      },
+      "shuffle": {
+        "name": "Shuffle"
+      }
+    },
+    "sensor": {
+      "air_quality": {
+        "name": "Air quality"
+      },
+      "air_quality_carbon_monoxide": {
+        "name": "Carbon monoxide"
+      },
+      "air_quality_humidity": {
+        "name": "Humidity"
+      },
+      "air_quality_indoor_air_quality": {
+        "name": "Indoor air quality"
+      },
+      "air_quality_particulate_matter": {
+        "name": "Particulate matter"
+      },
+      "air_quality_volatile_organic_compounds": {
+        "name": "Volatile organic compounds"
+      },
+      "temperature": {
+        "name": "Temperature"
+      },
+      "next_alarm": {
+        "name": "Next alarm"
+      },
+      "next_timer": {
+        "name": "Next timer"
+      },
+      "next_reminder": {
+        "name": "Next reminder"
+      }
+    }
+  },
   "issues": {
     "deprecated_yaml_configuration": {
       "description": "YAML configuration of Alexa Media Player is deprecated.\nPlease remove `alexa_media` from your configuration, restart Home Assistant and use the UI to configure it instead.\nSettings > Devices & services > Integrations > ADD INTEGRATION",

--- a/custom_components/alexa_media/translations/fr.json
+++ b/custom_components/alexa_media/translations/fr.json
@@ -11,7 +11,7 @@
       "identifier_exists": "L'adresse e-mail pour cette URL Alexa est déjà enregistrée",
       "invalid_auth": "La connexion a échoué. Veuillez vérifier votre adresse e-mail, votre mot de passe et votre clé d'authentification.",
       "invalid_credentials": "Identifiants invalides",
-      "invalid_url": "L'URL n'est pas valide: {message}",
+      "invalid_url": "L'URL n'est pas valide : {message}",
       "oauth_error": "Impossible de terminer la connexion OAuth. Veuillez réessayer.",
       "unable_to_connect_hass_url": "Impossible de se connecter à l'URL locale de Home Assistant. Veuillez vérifier l'URL sous Paramètres > Système > Réseau > URL de Home Assistant > Réseau local",
       "unknown_error": "Erreur inconnue : {message}"
@@ -69,7 +69,7 @@
           "include_devices": "Inclure uniquement ces appareils (séparés par des virgules)",
           "public_url": "URL publique partagée avec les services externes hébergés",
           "queue_delay": "Délai pour regrouper plusieurs commandes (secondes)",
-          "scan_interval": "Fréquence d'interrogation programmée (secondes)",
+          "scan_interval": "Intervalle d'interrogation (secondes)",
           "should_get_network": "Découvrir le réseau Alexa"
         },
         "description": "* Champs obligatoires",
@@ -83,7 +83,7 @@
       "fields": {
         "email": {
           "description": "Adresse e-mail du compte Alexa ou liste d'adresses (facultatif). Si vide, tous les comptes connus seront actualisés.",
-          "name": "Adresse email"
+          "name": "Adresse e-mail"
         }
       },
       "name": "Activer la découverte du réseau"


### PR DESCRIPTION
## Summary
- Add `has_entity_name=True` and `translation_key` support for sensors and switches
- Follows Home Assistant Quality Scale rule #16 (entity-translations)

### Translated entities

**Sensors:**
- `temperature` - Temperature sensor
- `air_quality` - Air quality sensor (5 subtypes: carbon_monoxide, humidity, indoor_air_quality, particulate_matter, volatile_organic_compounds)
- `next_alarm`, `next_timer`, `next_reminder` - Notification sensors

**Switches:**
- `do_not_disturb`, `shuffle`, `repeat`

## Test plan
- [ ] Verify sensors display translated names in HA UI
- [ ] Verify switches display translated names in HA UI
- [ ] Test with different HA language settings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Sensors and switches now display with standardized, localized entity names for enhanced clarity and consistency.
  * Added English translations for all sensor and switch entities, including temperature, air quality monitoring, alarm/timer/reminder notifications, and device controls.
  * Enhanced French translations with improved terminology and formatting in configuration messages and service descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->