### PR TITLE
feat: add entity translations for sensors and switches

### DIFF
--- a/custom_components/alexa_media/strings.json
+++ b/custom_components/alexa_media/strings.json
@@ -127,6 +127,51 @@
       }
     }
   },
+  "entity": {
+    "switch": {
+      "do_not_disturb": {
+        "name": "Do not disturb"
+      },
+      "shuffle": {
+        "name": "Shuffle"
+      },
+      "repeat": {
+        "name": "Repeat"
+      }
+    },
+    "sensor": {
+      "temperature": {
+        "name": "Temperature"
+      },
+      "air_quality": {
+        "name": "Air quality"
+      },
+      "air_quality_carbon_monoxide": {
+        "name": "Carbon monoxide"
+      },
+      "air_quality_humidity": {
+        "name": "Humidity"
+      },
+      "air_quality_indoor_air_quality": {
+        "name": "Indoor air quality"
+      },
+      "air_quality_particulate_matter": {
+        "name": "Particulate matter"
+      },
+      "air_quality_volatile_organic_compounds": {
+        "name": "Volatile organic compounds"
+      },
+      "next_alarm": {
+        "name": "Next alarm"
+      },
+      "next_timer": {
+        "name": "Next timer"
+      },
+      "next_reminder": {
+        "name": "Next reminder"
+      }
+    }
+  },
   "issues": {
     "deprecated_yaml_configuration": {
       "title": "YAML configuration is deprecated",

--- a/custom_components/alexa_media/switch.py
+++ b/custom_components/alexa_media/switch.py
@@ -171,17 +171,19 @@ async def async_unload_entry(hass, entry) -> bool:
 class AlexaMediaSwitch(SwitchDevice, AlexaMedia):
     """Representation of a Alexa Media switch."""
 
+    _attr_has_entity_name = True
+
     def __init__(
         self,
         client,
         switch_property: str,
         switch_function: str,
-        name="Alexa",
+        unique_id_suffix: str = "switch",
     ):
         """Initialize the Alexa Switch device."""
         # Class info
         self._client = client
-        self._name = name
+        self._unique_id_suffix = unique_id_suffix
         self._switch_property = switch_property
         self._switch_function = switch_function
         super().__init__(client, client._login)
@@ -244,7 +246,7 @@ class AlexaMediaSwitch(SwitchDevice, AlexaMedia):
             _LOGGER.debug(
                 "Requesting update of %s due to %s switch to %s",
                 self._client,
-                self._name,
+                self._unique_id_suffix,
                 state,
             )
             await self._client.async_update()
@@ -278,12 +280,7 @@ class AlexaMediaSwitch(SwitchDevice, AlexaMedia):
     @property
     def unique_id(self):
         """Return the unique ID."""
-        return self._client.unique_id + "_" + self._name
-
-    @property
-    def name(self):
-        """Return the name of the switch."""
-        return f"{self._client.name} {self._name} switch"
+        return self._client.unique_id + "_" + self._unique_id_suffix
 
     @property
     def device_class(self):
@@ -333,6 +330,8 @@ class AlexaMediaSwitch(SwitchDevice, AlexaMedia):
 class DNDSwitch(AlexaMediaSwitch):
     """Representation of a Alexa Media Do Not Disturb switch."""
 
+    _attr_translation_key = "do_not_disturb"
+
     def __init__(self, client):
         """Initialize the Alexa Switch."""
         # Class info
@@ -340,7 +339,7 @@ class DNDSwitch(AlexaMediaSwitch):
             client,
             "dnd_state",
             "set_dnd_state",
-            "do not disturb",
+            "do not disturb",  # Keep original suffix for backward compatibility
         )
 
     @property
@@ -379,6 +378,8 @@ class DNDSwitch(AlexaMediaSwitch):
 class ShuffleSwitch(AlexaMediaSwitch):
     """Representation of a Alexa Media Shuffle switch."""
 
+    _attr_translation_key = "shuffle"
+
     def __init__(self, client):
         """Initialize the Alexa Switch."""
         # Class info
@@ -397,6 +398,8 @@ class ShuffleSwitch(AlexaMediaSwitch):
 
 class RepeatSwitch(AlexaMediaSwitch):
     """Representation of a Alexa Media Repeat switch."""
+
+    _attr_translation_key = "repeat"
 
     def __init__(self, client):
         """Initialize the Alexa Switch."""

--- a/custom_components/alexa_media/translations/en.json
+++ b/custom_components/alexa_media/translations/en.json
@@ -53,6 +53,51 @@
       }
     }
   },
+  "entity": {
+    "switch": {
+      "do_not_disturb": {
+        "name": "Do not disturb"
+      },
+      "repeat": {
+        "name": "Repeat"
+      },
+      "shuffle": {
+        "name": "Shuffle"
+      }
+    },
+    "sensor": {
+      "air_quality": {
+        "name": "Air quality"
+      },
+      "air_quality_carbon_monoxide": {
+        "name": "Carbon monoxide"
+      },
+      "air_quality_humidity": {
+        "name": "Humidity"
+      },
+      "air_quality_indoor_air_quality": {
+        "name": "Indoor air quality"
+      },
+      "air_quality_particulate_matter": {
+        "name": "Particulate matter"
+      },
+      "air_quality_volatile_organic_compounds": {
+        "name": "Volatile organic compounds"
+      },
+      "temperature": {
+        "name": "Temperature"
+      },
+      "next_alarm": {
+        "name": "Next alarm"
+      },
+      "next_timer": {
+        "name": "Next timer"
+      },
+      "next_reminder": {
+        "name": "Next reminder"
+      }
+    }
+  },
   "issues": {
     "deprecated_yaml_configuration": {
       "description": "YAML configuration of Alexa Media Player is deprecated.\nPlease remove `alexa_media` from your configuration, restart Home Assistant and use the UI to configure it instead.\nSettings > Devices & services > Integrations > ADD INTEGRATION",


### PR DESCRIPTION
## Summary
- Add `has_entity_name=True` and `translation_key` support for sensors and switches
- Follows Home Assistant Quality Scale rule #16 (entity-translations)

### Translated entities

**Sensors:**
- `temperature` - Temperature sensor
- `air_quality` - Air quality sensor (5 subtypes: carbon_monoxide, humidity, indoor_air_quality, particulate_matter, volatile_organic_compounds)
- `next_alarm`, `next_timer`, `next_reminder` - Notification sensors

**Switches:**
- `do_not_disturb`, `shuffle`, `repeat`

## Test plan
- [ ] Verify sensors display translated names in HA UI
- [ ] Verify switches display translated names in HA UI
- [ ] Test with different HA language settings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved entity naming and localization for sensors (temperature, multiple air-quality types) and for next alarm/timer/reminder; switches gain entity naming and translation keys (do not disturb, shuffle, repeat).
* **Documentation**
  * Expanded translation files and added entity localization entries to provide localized names for new/updated entities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->