### PR TITLE
fix: preserve notification sensor unique_ids on upgrade (#3345)

### DIFF
--- a/custom_components/alexa_media/sensor.py
+++ b/custom_components/alexa_media/sensor.py
@@ -1024,7 +1024,7 @@ class AlarmSensor(AlexaMediaNotificationSensor):
             n_json,
             "date_time",
             account,
-            "Next alarm",
+            f"next {self._type}",
             "mdi:alarm",
             debug=debug,
         )
@@ -1044,7 +1044,7 @@ class TimerSensor(AlexaMediaNotificationSensor):
             n_json,
             "remainingTime",
             account,
-            "Next timer",
+            f"next {self._type}",
             (
                 "mdi:timer-outline"
                 if (version.parse(HA_VERSION) >= version.parse("0.113.0"))
@@ -1106,7 +1106,7 @@ class ReminderSensor(AlexaMediaNotificationSensor):
             n_json,
             "alarmTime",
             account,
-            "Next reminder",
+            f"next {self._type}",
             "mdi:reminder",
             debug=debug,
         )


### PR DESCRIPTION
## Summary
- Restore original `f"next {self._type}"` name parameter in AlarmSensor, TimerSensor, and ReminderSensor constructors
- PR #3339 changed these from `"next Alarm"` to `"Next alarm"`, altering `_attr_unique_id` and causing HA to create duplicate entities with `_2` suffix on upgrade from pre-5.12.0
- With `has_entity_name=True` + `translation_key`, the `name` parameter only affects `unique_id`, not the displayed name

Fixes #3345

## Test plan
- [x] Deployed pre-#3339 version to create entities with original unique_ids (`_next Alarm`)
- [x] Deployed buggy version → confirmed `_3` suffixed duplicates appear in entity registry
- [x] Deployed fix → confirmed original entities reused, zero duplicates
- [x] Verified translated names still work correctly (French: `prochaine_alarme`, `prochain_minuteur`, `prochain_rappel`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Alexa notification sensors now display names that dynamically adjust based on sensor type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->