### PR TITLE
test: remove test_supported_features_with_import_error

### DIFF
--- a/tests/test_alarm_control_panel.py
+++ b/tests/test_alarm_control_panel.py
@@ -790,19 +790,6 @@ class TestSupportedFeatures:
         # ARM_AWAY should be supported
         assert features is not None
 
-    def test_supported_features_with_import_error(self):
-        """Test supported_features returns 0 when import fails.
-
-        Note: The ImportError branch at lines 241-242 is for backwards
-        compatibility with older Home Assistant versions. It cannot be easily
-        tested without uninstalling the module. This test documents the expected
-        behavior.
-        """
-        # This test documents that supported_features returns 0
-        # when AlarmControlPanelEntityFeature cannot be imported
-        # (older Home Assistant versions)
-        pass
-
 
 class TestAttributeErrorHandling:
     """Test AttributeError handling in _async_alarm_set."""


### PR DESCRIPTION
The test only contained pass, so it always succeeded without validating the documented ImportError compatibility path. Since that branch is only relevant to older Home Assistant versions and is not straightforward to exercise in the current test environment, removing the empty test avoids false coverage.

Fixes #3322 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Removed a placeholder test case from the alarm control panel test suite, streamlining test coverage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alandtse/alexa_media_player/pull/3464)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->