### PR TITLE
fix: blocking call warning introduced by Home Assistant 2026.7

### DIFF
--- a/custom_components/alexa_media/config_flow.py
+++ b/custom_components/alexa_media/config_flow.py
@@ -382,7 +382,6 @@ class AlexaMediaFlowHandler(config_entries.ConfigFlow):
                     self.login,
                     str(URL(self.config.get(CONF_HASS_URL)).with_path(AUTH_PROXY_PATH)),
                 )
-
                 self.proxy.session_factory = lambda: create_async_httpx_client(
                     self.hass,
                     verify_ssl=True,
@@ -394,16 +393,6 @@ class AlexaMediaFlowHandler(config_entries.ConfigFlow):
                         pool=30.0,
                     ),
                 )
-
-            #                self.proxy.session_factory = lambda: httpx.AsyncClient(
-            #                    timeout=httpx.Timeout(
-            #                        connect=30.0,
-            #                        read=120.0,
-            #                        write=30.0,
-            #                        pool=30.0,
-            #                    ),
-            #                )
-
             except ValueError as ex:
                 return self.async_show_form(
                     step_id="user",

--- a/custom_components/alexa_media/config_flow.py
+++ b/custom_components/alexa_media/config_flow.py
@@ -43,6 +43,7 @@ from homeassistant.const import (
 from homeassistant.core import callback
 from homeassistant.data_entry_flow import FlowResult, UnknownFlow
 from homeassistant.exceptions import Unauthorized
+from homeassistant.helpers.httpx_client import create_async_httpx_client
 from homeassistant.helpers.network import NoURLAvailableError, get_url
 from homeassistant.util import slugify
 import httpx
@@ -381,7 +382,11 @@ class AlexaMediaFlowHandler(config_entries.ConfigFlow):
                     self.login,
                     str(URL(self.config.get(CONF_HASS_URL)).with_path(AUTH_PROXY_PATH)),
                 )
-                self.proxy.session_factory = lambda: httpx.AsyncClient(
+
+                self.proxy.session_factory = lambda: create_async_httpx_client(
+                    self.hass,
+                    verify_ssl=True,
+                    follow_redirects=False,
                     timeout=httpx.Timeout(
                         connect=30.0,
                         read=120.0,
@@ -389,6 +394,16 @@ class AlexaMediaFlowHandler(config_entries.ConfigFlow):
                         pool=30.0,
                     ),
                 )
+
+#                self.proxy.session_factory = lambda: httpx.AsyncClient(
+#                    timeout=httpx.Timeout(
+#                        connect=30.0,
+#                        read=120.0,
+#                        write=30.0,
+#                        pool=30.0,
+#                    ),
+#                )
+
             except ValueError as ex:
                 return self.async_show_form(
                     step_id="user",

--- a/custom_components/alexa_media/config_flow.py
+++ b/custom_components/alexa_media/config_flow.py
@@ -395,14 +395,14 @@ class AlexaMediaFlowHandler(config_entries.ConfigFlow):
                     ),
                 )
 
-#                self.proxy.session_factory = lambda: httpx.AsyncClient(
-#                    timeout=httpx.Timeout(
-#                        connect=30.0,
-#                        read=120.0,
-#                        write=30.0,
-#                        pool=30.0,
-#                    ),
-#                )
+            #                self.proxy.session_factory = lambda: httpx.AsyncClient(
+            #                    timeout=httpx.Timeout(
+            #                        connect=30.0,
+            #                        read=120.0,
+            #                        write=30.0,
+            #                        pool=30.0,
+            #                    ),
+            #                )
 
             except ValueError as ex:
                 return self.async_show_form(


### PR DESCRIPTION
## Summary

Replace the direct creation of `httpx.AsyncClient` used by the Alexa authentication proxy with Home Assistant's `create_async_httpx_client()` helper.

This resolves the blocking call warnings introduced by Home Assistant 2026.7 while preserving the existing proxy behavior.

## Changes

- Replace `httpx.AsyncClient()` with `create_async_httpx_client()`
- Preserve the existing custom timeout values
- Preserve `follow_redirects=False` required by the authentication proxy flow

## Testing

- Home Assistant 2026.7.0b1
- Verified that the `load_verify_locations()` blocking call warning no longer occurs during Alexa Media Player authentication.

## Fixes

- #3479

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved proxy session setup for the integration, helping connections use more consistent SSL and redirect handling.
  * Kept request timeout behavior unchanged while making network client creation more reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->