### PR TITLE
fix: stop last_called probe crash-looping on serialization TypeError

### DIFF
--- a/custom_components/alexa_media/__init__.py
+++ b/custom_components/alexa_media/__init__.py
@@ -1530,7 +1530,32 @@ async def setup_alexa(hass, config_entry, login_obj: AlexaLogin):
                     if not login_live or not _network_allowed(login_live):
                         await asyncio.sleep(5)
                         continue
-                    await account_live["last_called_probe_event"].wait()
+                    # Stop this worker if the login object has been torn down (entry
+                    # reload/unload) so it cannot orphan onto a dead login and keep
+                    # hammering the API across reloads.
+                    if getattr(login_live, "close_requested", False) or (
+                        getattr(login_live, "session", None) is not None
+                        and login_live.session.closed
+                    ):
+                        return
+                    # Skip probing while the login is unhealthy: the request would be
+                    # built with a missing csrf / None header and raise a serialization
+                    # TypeError, and hammering the history API while logged-out can
+                    # hinder re-auth. Poll quietly until the login recovers.
+                    _status = getattr(login_live, "status", None)
+                    if not (_status and _status.get("login_successful")):
+                        await asyncio.sleep(15)
+                        continue
+                    # Bounded wait so that if the login is torn down while we are
+                    # idle here, the next iteration's teardown guard exits promptly
+                    # instead of parking on the event forever.
+                    try:
+                        await asyncio.wait_for(
+                            account_live["last_called_probe_event"].wait(),
+                            timeout=15,
+                        )
+                    except asyncio.TimeoutError:
+                        continue
                     account_live["last_called_probe_event"].clear()
 
                     if not skip_debounce:
@@ -1630,24 +1655,22 @@ async def setup_alexa(hass, config_entry, login_obj: AlexaLogin):
                                     max_record_size=max_record_size,
                                 )
                             except TypeError as exc:
-                                # Known alexapy/aiohttp edge case: None header key, etc.
+                                # A serialization TypeError (e.g. a None header key
+                                # when the login is half-torn-down) is not transient
+                                # within a session: back off and do NOT re-arm. The
+                                # old behavior crash-looped ~every 11s, hammering the
+                                # API. Wait for the next genuine push trigger instead.
+                                backoff = max(LAST_CALLED_CONN_BACKOFF_S, 60.0)
                                 account_live["last_called_probe_next_allowed"] = (
-                                    time.monotonic() + LAST_CALLED_CONN_BACKOFF_S
+                                    time.monotonic() + backoff
                                 )
                                 _LOGGER.warning(
-                                    "%s: last_called probe API TypeError (%s): %s",
+                                    "%s: last_called probe API TypeError (%s): %s; "
+                                    "backing off, not re-arming",
                                     hide_email(email),
                                     trigger_cmd,
                                     exc,
-                                    exc_info=True,
                                 )
-                                # NOTE:
-                                # We intentionally re-arm the probe (set event + backoff) on this TypeError
-                                # because this path is typically caused by transient alexapy/aiohttp issues
-                                # (e.g., None header key). Unlike Login/Connection errors, we retry quickly
-                                # to avoid losing last_called updates triggered by push events.
-                                skip_debounce = True
-                                account_live["last_called_probe_event"].set()
                                 break
 
                             if records is None:


### PR DESCRIPTION
## Summary

Hardens the `last_called` probe worker so it no longer crash-loops and
hammers Amazon's API when the login is unhealthy.

## Problem

When the Amazon login is unhealthy (e.g. the session expired, or the login
object is half-torn-down after a config-entry reload),
`AlexaAPI.get_customer_history_records()` raises:

```
TypeError: Cannot serialize non-str key None
```

from aiohttp's header writer (`_http_writer._serialize_headers`). The probe's
`except TypeError` handler re-armed the probe immediately (`skip_debounce =
True` + `event.set()`), so the worker retried roughly **every ~11s** —
flooding the log with the warning + traceback and continuously hitting the
customer-history API while logged out, which can itself hinder
re-authentication. The worker also kept running on the old login object
across a config-entry reload (orphaned task).

## Fix

- On the serialization `TypeError`, back off ≥60s and **don't** self-re-arm —
  wait for the next genuine push trigger instead.
- Skip probing while the login is unhealthy (`status` not `login_successful`),
  so the malformed request is never built in the first place.
- Stop the worker if its login object has been torn down (`close_requested` /
  closed `session`), so it can't orphan onto a dead login and keep probing
  across reloads.

Healthy-login behavior (fast `last_called` updates on push events) is
unchanged.

## Testing

- Reproduced live: after an HA restart the Amazon session expired and the
  probe crash-looped every ~11s with the `TypeError` above while all Echo
  entities were `unavailable`.
- With this change deployed, the log spam stops and the worker stays quiet
  while logged out; once the login recovers, `last_called` updates resume.
- `black`, `isort`, `flake8`, and `codespell` pass on the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability of background account status probing after reloads, disconnects, or teardown.
  * Paused probing when the account is not logged in or login health is unavailable, resuming only after recovery.
  * Treated specific customer history errors as non-transient to prevent rapid retry/debounce loops and reduce repeated failures.
  * Ensured probe waits won’t block indefinitely during shutdown by adding a bounded wait timeout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->