### PR TITLE
fix: bump alexapy to 1.29.25

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -21,7 +21,7 @@ Always reference these instructions first and fallback to search or bash command
   - `poetry install` -- takes 2-3 minutes on first run. NEVER CANCEL. Set timeout to 10+ minutes.
   - If Poetry fails due to version conflicts: `poetry lock --no-update` first, then `poetry install`
 - **FALLBACK**: Install core dependencies manually if Poetry fails:
-  - `pip3 install alexapy==1.29.25 packaging wrapt async_timeout aiohttp dictor>=0.1.12,<0.2`
+  - `pip3 install alexapy==1.29.25 packaging wrapt async_timeout aiohttp "dictor>=0.1.12,<0.2"`
   - This allows basic functionality but may miss dev dependencies
 
 ### Linting and Code Quality (ALWAYS run before committing)
@@ -109,7 +109,7 @@ cat custom_components/alexa_media/manifest.json  # HA integration manifest
 
 ### Dependency Management
 
-- **Core dependencies**: alexapy==1.29.25, aiohttp>=3.8.1, packaging>=20.3, wrapt>=1.12.1, dictor>=0.1.12,<0.2
+- **Core dependencies**: alexapy==1.29.25, aiohttp>=3.8.1, packaging>=20.3, wrapt>=1.14.0, dictor>=0.1.12,<0.2
 - **Dev dependencies**: homeassistant>=2025.2.0, pytest-homeassistant-custom-component>=0.13.107
 - Add new dependencies to `pyproject.toml` then run `poetry lock`
 - **NEVER CANCEL**: `poetry lock` can take 60+ seconds. Set timeout to 10+ minutes.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -21,7 +21,7 @@ Always reference these instructions first and fallback to search or bash command
   - `poetry install` -- takes 2-3 minutes on first run. NEVER CANCEL. Set timeout to 10+ minutes.
   - If Poetry fails due to version conflicts: `poetry lock --no-update` first, then `poetry install`
 - **FALLBACK**: Install core dependencies manually if Poetry fails:
-  - `pip3 install alexapy==1.29.24 packaging wrapt async_timeout aiohttp dictor>=0.1.12,<0.2`
+  - `pip3 install alexapy==1.29.25 packaging wrapt async_timeout aiohttp dictor>=0.1.12,<0.2`
   - This allows basic functionality but may miss dev dependencies
 
 ### Linting and Code Quality (ALWAYS run before committing)
@@ -109,7 +109,7 @@ cat custom_components/alexa_media/manifest.json  # HA integration manifest
 
 ### Dependency Management
 
-- **Core dependencies**: alexapy==1.29.24, aiohttp>=3.8.1, packaging>=20.3, wrapt>=1.12.1, dictor>=0.1.12,<0.2
+- **Core dependencies**: alexapy==1.29.25, aiohttp>=3.8.1, packaging>=20.3, wrapt>=1.12.1, dictor>=0.1.12,<0.2
 - **Dev dependencies**: homeassistant>=2025.2.0, pytest-homeassistant-custom-component>=0.13.107
 - Add new dependencies to `pyproject.toml` then run `poetry lock`
 - **NEVER CANCEL**: `poetry lock` can take 60+ seconds. Set timeout to 10+ minutes.

--- a/custom_components/alexa_media/manifest.json
+++ b/custom_components/alexa_media/manifest.json
@@ -9,7 +9,7 @@
   "issue_tracker": "https://github.com/alandtse/alexa_media_player/issues",
   "loggers": ["alexapy", "authcaptureproxy"],
   "requirements": [
-    "alexapy==1.29.24",
+    "alexapy==1.29.25",
     "packaging>=20.3",
     "wrapt>=1.14.0",
     "dictor>=0.1.12,<0.2"

--- a/poetry.lock
+++ b/poetry.lock
@@ -283,14 +283,14 @@ tzdata = ">=2024.1"
 
 [[package]]
 name = "alexapy"
-version = "1.29.24"
+version = "1.29.25"
 description = "Python API to control Amazon Echo Devices Programmatically."
 optional = false
 python-versions = "<4,>=3.11"
 groups = ["main"]
 files = [
-    {file = "alexapy-1.29.24-py3-none-any.whl", hash = "sha256:899167fc22adba074dc916c02e1ddf05ac885997f240da49b935aa9c59201242"},
-    {file = "alexapy-1.29.24.tar.gz", hash = "sha256:3d616463e79c0ddae784fb0a15789a519408c03193999e5c97a275601fa8a15e"},
+    {file = "alexapy-1.29.25-py3-none-any.whl", hash = "sha256:ec7903692541178e6dcd7e46097de2cead4aad011367a78f07cb4356bc8a30ef"},
+    {file = "alexapy-1.29.25.tar.gz", hash = "sha256:2b5740663050486677daf67ff2489531426f7750d27248a1d75a19ff127f1076"},
 ]
 
 [package.dependencies]
@@ -5946,4 +5946,4 @@ ifaddr = ">=0.1.7"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.13,<4.0"
-content-hash = "2199118a8ce43b4b12b531b7c144363f5872aab57483cf590f736eaf392e22f3"
+content-hash = "82eee176ac1cb9ffa9b56c12aec646aacd8ad6786b654412c51e884c75e7a3da"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ packages = [
 
 [tool.poetry.dependencies]
 python = ">=3.13,<4.0"
-alexapy = "1.29.24"
+alexapy = "1.29.25"
 aiohttp = ">=3.8.1"
 packaging = ">=20.3"
 wrapt = ">=1.12.1"


### PR DESCRIPTION
## Plan: Bump alexapy from 1.29.24 to 1.29.25

- [x] Update alexapy version in `.github/copilot-instructions.md` (documentation)
- [x] Update alexapy version in `custom_components/alexa_media/manifest.json`
- [x] Update alexapy version in `pyproject.toml`
- [x] Update `poetry.lock` using `poetry update alexapy` command
- [x] Verify linting passes (yamllint, codespell, prettier)

## Fixes:

- #3490
- #3491
- #3492


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped the `alexapy` dependency from `1.29.24` to `1.29.25` to stay current.
  * Raised the minimum supported `wrapt` version to `>=1.14.0`.
  * Updated dependency guidance so installation/setup instructions and version lists remain consistent across the project.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->