### PR TITLE
refactor: mark unused _is_active_notification parameter

### DIFF
--- a/custom_components/alexa_media/sensor.py
+++ b/custom_components/alexa_media/sensor.py
@@ -664,7 +664,7 @@ class AlexaMediaNotificationSensor(SensorEntity):
         next_item["snoozedToTime"] = None
         return value
 
-    def _is_active_notification(self, item, now):
+    def _is_active_notification(self, item, _now):
         """Return whether a notification should be considered active."""
         status = item[1].get("status")
         if status == "ON":


### PR DESCRIPTION
Rename the unused `now` parameter to `_now` after the snoozed alarm refactor. The parameter remains in the signature to preserve the call interface while avoiding unused-argument lint warnings.

Resolves issue #3505

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Minor internal cleanup with no expected impact on app behavior or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->