### PR TITLE
chore: align minimum wrapt version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ python = ">=3.13,<4.0"
 alexapy = "1.29.25"
 aiohttp = ">=3.8.1"
 packaging = ">=20.3"
-wrapt = ">=1.12.1"
+wrapt = ">=1.14.0"
 dictor = ">=0.1.12,<0.2"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
- Align the minimum `wrapt` dependency declared in `pyproject.toml` with the runtime requirement in `manifest.json.`
- Refresh `poetry.lock` so development environments resolve the same minimum version required at runtime.

Resolves issue #3507 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a third-party dependency requirement to a newer supported version, helping keep the project current and maintain compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->