### PR TITLE
fix: strip whitespace from Amazon region domain

### DIFF
--- a/custom_components/alexa_media/config_flow.py
+++ b/custom_components/alexa_media/config_flow.py
@@ -820,6 +820,7 @@ class AlexaMediaFlowHandler(config_entries.ConfigFlow):
         if CONF_PASSWORD in user_input:
             self.config[CONF_PASSWORD] = user_input[CONF_PASSWORD]
         if CONF_URL in user_input:
+            # Remove accidental whitespace introduced by mobile keyboards/paste.
             self.config[CONF_URL] = "".join(user_input[CONF_URL].split())
         if CONF_PUBLIC_URL in user_input:
             if not user_input[CONF_PUBLIC_URL].endswith("/"):

--- a/custom_components/alexa_media/config_flow.py
+++ b/custom_components/alexa_media/config_flow.py
@@ -820,7 +820,7 @@ class AlexaMediaFlowHandler(config_entries.ConfigFlow):
         if CONF_PASSWORD in user_input:
             self.config[CONF_PASSWORD] = user_input[CONF_PASSWORD]
         if CONF_URL in user_input:
-            self.config[CONF_URL] = user_input[CONF_URL]
+            self.config[CONF_URL] = "".join(user_input[CONF_URL].split())
         if CONF_PUBLIC_URL in user_input:
             if not user_input[CONF_PUBLIC_URL].endswith("/"):
                 user_input[CONF_PUBLIC_URL] = user_input[CONF_PUBLIC_URL] + "/"

--- a/poetry.lock
+++ b/poetry.lock
@@ -5946,4 +5946,4 @@ ifaddr = ">=0.1.7"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.13,<4.0"
-content-hash = "82eee176ac1cb9ffa9b56c12aec646aacd8ad6786b654412c51e884c75e7a3da"
+content-hash = "6c68608511837b8a2296dcd583e654d273f9379745868ff5bd32ba16d11dcd27"

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -2,8 +2,8 @@
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import pytest
 from homeassistant.const import CONF_URL
+import pytest
 
 from custom_components.alexa_media.config_flow import AlexaMediaFlowHandler
 from custom_components.alexa_media.const import DATA_ALEXAMEDIA

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -3,6 +3,7 @@
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from homeassistant.const import CONF_URL
 
 from custom_components.alexa_media.config_flow import AlexaMediaFlowHandler
 from custom_components.alexa_media.const import DATA_ALEXAMEDIA
@@ -352,3 +353,15 @@ class TestConfigFlowInvalidOtpKeyDataSchema:
             "step_id='user' not found in exception handler. "
             "The handler should return users to the user step for correction."
         )
+
+
+class TestConfigFlowUrlCleanup:
+    """Tests for cleaning Amazon region domains in config flow."""
+
+    def test_save_user_input_strips_whitespace_from_url(self):
+        """Test that accidental whitespace is removed from the Amazon domain."""
+        flow = AlexaMediaFlowHandler()
+
+        flow._save_user_input_to_config({CONF_URL: "amazon.com. au"})
+
+        assert flow.config[CONF_URL] == "amazon.com.au"


### PR DESCRIPTION
## Summary
- strip whitespace from the Amazon region domain before saving config flow input
- add a regression test for an accidental space in `amazon.com.au`

## Why
A mobile browser/input path can submit `amazon.com.au` as `amazon.com. au`, which then causes alexapy to try `alexa.amazon.com. au` and fail DNS resolution with `Misformatted domain name`.

Removing whitespace from this domain field keeps the existing behavior for valid domains while tolerating accidental spaces from paste/autofill/mobile input.

## Testing
- `python3 -m py_compile custom_components/alexa_media/config_flow.py tests/test_config_flow.py`

I could not run pytest in this local shell because the repo's Python/Home Assistant test dependencies are not installed here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved setup handling for Amazon region URLs by cleaning accidental whitespace before saving.
  * Prevents malformed entries (for example, `amazon.com. au`) from being stored, reducing connection and configuration issues caused by copy/paste input mistakes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->