### PR TITLE
feat!: enrollment-only auth — paste-URL flow, no stored password/TOTP seed

### DIFF
--- a/custom_components/alexa_media/__init__.py
+++ b/custom_components/alexa_media/__init__.py
@@ -23,7 +23,6 @@ from alexapy import (
     AlexaLogin,
     AlexapyConnectionError,
     AlexapyLoginError,
-    AuthTerminalError,
     HTTP2EchoClient,
     __version__ as alexapy_version,
     hide_serial,
@@ -929,21 +928,32 @@ async def async_setup_entry(hass, config_entry):
             except (JSONDecodeError, ValueError, aiohttp.ClientError) as ex:
                 _LOGGER.debug("[BOOT] Bootstrap cookie auth check failed: %s", ex)
         if not cookie_login_ok:
-            try:
-                await login.login(cookies=cookies)
-            except AuthTerminalError as err:
-                # The stored device registration is dead — only interactive
-                # re-enrollment can recover it.
-                raise ConfigEntryAuthFailed(str(err)) from err
+            await login.login(cookies=cookies)
         _LOGGER.debug("[BOOT] login completed in %.2fs", time.monotonic() - _t)
         _t = time.monotonic()
-        if await test_login_status(hass, config_entry, login):
-            _LOGGER.debug("[BOOT] test_login_status in %.2fs", time.monotonic() - _t)
-            if secure and secure_store is not None:
-                # First successful round-trip commits the migrated/enrolled
+        if secure:
+            # Secure entries bootstrap purely from the stored refresh token.
+            # Transient/network failures raise AlexapyConnectionError and are
+            # mapped to ConfigEntryNotReady below. Any other failure to reach a
+            # logged-in state means the stored registration is dead, so surface
+            # ConfigEntryAuthFailed to start the paste-URL reauth flow — this is
+            # the terminal-vs-transient classification the design promises.
+            if not (login.status and login.status.get("login_successful")):
+                raise ConfigEntryAuthFailed(
+                    "Stored device credentials were rejected; re-enrollment required"
+                )
+            if secure_store is not None:
+                # First successful refresh commits the migrated/enrolled
                 # credentials and drains any legacy secrets from the entry.
                 await secure_store.async_mark_validated()
                 await _cleanup_legacy_secrets(hass, config_entry)
+            await setup_alexa(hass, config_entry, login)
+            _LOGGER.debug(
+                "[BOOT] setup_entry total: %.2fs", time.monotonic() - _boot_start
+            )
+            return True
+        if await test_login_status(hass, config_entry, login):
+            _LOGGER.debug("[BOOT] test_login_status in %.2fs", time.monotonic() - _t)
             _t = time.monotonic()
             await setup_alexa(hass, config_entry, login)
             _LOGGER.debug(
@@ -3310,7 +3320,16 @@ async def async_remove_entry(hass, entry) -> bool:
         try:
             await store.async_remove()
         except Exception as ex:  # noqa: BLE001
-            _LOGGER.debug("Could not remove secure store: %s", ex)
+            # Do not hide this: a leftover store still holds a replayable refresh
+            # token. Surface it at error level with the path so it can be removed
+            # manually; deregistration above already best-effort revoked it.
+            _LOGGER.error(
+                "Failed to delete secure credential store for %s (%s). A refresh "
+                "token may remain in .storage/%s — delete it manually.",
+                obfuscated_email,
+                ex,
+                store.key,
+            )
         _LOGGER.debug("Config entry %s removed.", obfuscated_email)
         return True
 

--- a/custom_components/alexa_media/__init__.py
+++ b/custom_components/alexa_media/__init__.py
@@ -23,6 +23,7 @@ from alexapy import (
     AlexaLogin,
     AlexapyConnectionError,
     AlexapyLoginError,
+    AuthTerminalError,
     HTTP2EchoClient,
     __version__ as alexapy_version,
     hide_serial,
@@ -45,7 +46,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.data_entry_flow import UnknownFlow
-from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers import config_validation as cv, device_registry as dr
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
@@ -55,7 +56,8 @@ from homeassistant.util import dt, slugify
 import voluptuous as vol
 
 from .alexa_entity import AlexaEntityData, get_entity_data, parse_alexa_entities
-from .config_flow import in_progress_instances
+from .config_flow import CONFIG_VERSION, in_progress_instances
+from .secure_store import SecureCredentialStore
 from .const import (
     ALEXA_COMPONENTS,
     CONF_ACCOUNTS,
@@ -68,6 +70,7 @@ from .const import (
     CONF_PUBLIC_URL,
     CONF_QUEUE_DELAY,
     CONF_SCAN_INTERVAL,
+    CONF_SECURE,
     DATA_ALEXAMEDIA,
     DATA_LISTENER,
     DEFAULT_EXTENDED_ENTITY_DISCOVERY,
@@ -475,6 +478,88 @@ async def async_setup(hass, config):
     return True
 
 
+async def async_migrate_entry(hass, config_entry) -> bool:
+    """Migrate a legacy entry to the secure, credential-minimizing schema.
+
+    Local, lazy, and non-destructive (RFC #3523 migration design): copy the
+    existing ``refresh_token``/``mac_dms`` into the protected store and mark the
+    entry secure, but keep the legacy secrets until the first successful
+    refresh-plus-cookie round trip commits (``_cleanup_legacy_secrets``, called
+    from ``async_setup_entry``). No Amazon request happens here, so a transient
+    outage cannot strand the entry.
+    """
+    if config_entry.version >= CONFIG_VERSION:
+        return True
+    _LOGGER.debug(
+        "Migrating %s from schema v%s to v%s",
+        hide_email(config_entry.data.get(CONF_EMAIL, "")),
+        config_entry.version,
+        CONFIG_VERSION,
+    )
+    data = dict(config_entry.data)
+    oauth = data.get(CONF_OAUTH, {}) or {}
+    refresh_token = oauth.get("refresh_token")
+    if not refresh_token:
+        # Nothing to migrate to; the entry must re-enroll interactively. Mark it
+        # secure and bump the version so setup raises ConfigEntryAuthFailed and
+        # starts the paste-URL reauth flow.
+        hass.config_entries.async_update_entry(
+            config_entry,
+            data={**data, CONF_SECURE: True},
+            version=CONFIG_VERSION,
+        )
+        return True
+    store = SecureCredentialStore(hass, config_entry.entry_id)
+    await store.async_save(
+        {
+            "refresh_token": refresh_token,
+            "mac_dms": oauth.get("mac_dms"),
+            "serial": data.get("serial"),
+            "customer_id": oauth.get("customer_id"),
+            "domain": data.get(CONF_URL, "amazon.com"),
+        },
+        pending_validation=True,
+    )
+    # Keep legacy secrets in place until validation commits; only flip the marker
+    # and version now.
+    hass.config_entries.async_update_entry(
+        config_entry,
+        data={**data, CONF_SECURE: True},
+        version=CONFIG_VERSION,
+    )
+    return True
+
+
+async def _cleanup_legacy_secrets(hass, config_entry) -> None:
+    """Drop legacy at-rest secrets after the secure credentials validate.
+
+    Removes the password, TOTP seed, and inline oauth dict from the config
+    entry and deletes legacy cookie files. Only called after a successful
+    refresh-plus-cookie round trip, so migration can never strand an entry.
+    """
+    data = dict(config_entry.data)
+    legacy_keys = [CONF_PASSWORD, CONF_OTPSECRET, CONF_OAUTH]
+    removed = [key for key in legacy_keys if key in data]
+    if removed:
+        for key in removed:
+            data.pop(key, None)
+        hass.config_entries.async_update_entry(config_entry, data=data)
+        _LOGGER.debug(
+            "%s: cleared legacy secrets %s after secure validation",
+            hide_email(config_entry.data.get(CONF_EMAIL, "")),
+            removed,
+        )
+    email = config_entry.data.get(CONF_EMAIL, "")
+    for handle in (email, hide_email(email)):
+        cookiefile = hass.config.path(f".storage/{DOMAIN}.{handle}.pickle")
+        if os.path.exists(cookiefile):
+            try:
+                await alexapy_delete_cookie(cookiefile)
+                _LOGGER.debug("Deleted legacy cookiefile for %s", hide_email(email))
+            except (OSError, EOFError, TypeError, AttributeError) as ex:
+                _LOGGER.debug("Could not delete legacy cookiefile: %s", ex)
+
+
 def _store_and_dispatch_last_called(
     hass: HomeAssistant,
     email: str,
@@ -759,6 +844,24 @@ async def async_setup_entry(hass, config_entry):
     hass.data[DATA_ALEXAMEDIA]["accounts"][email]["second_account_index"] = uuid_dict[
         "index"
     ]
+    # Secure enrollment (RFC #3523): the durable device credentials live in a
+    # dedicated protected store, not the config entry. Load them here so the
+    # runtime bootstraps from the refresh token alone — no password, no seed,
+    # no persisted cookie file.
+    secure = bool(account.get(CONF_SECURE))
+    secure_store: SecureCredentialStore | None = None
+    secure_oauth: dict = account.get(CONF_OAUTH, {})
+    if secure:
+        secure_store = SecureCredentialStore(hass, config_entry.entry_id)
+        stored = await secure_store.async_load()
+        if not stored or not stored.get("refresh_token"):
+            raise ConfigEntryAuthFailed(
+                "No stored device credentials; interactive re-enrollment required"
+            )
+        secure_oauth = {
+            "refresh_token": stored["refresh_token"],
+            "mac_dms": stored.get("mac_dms"),
+        }
     login: AlexaLogin = hass.data[DATA_ALEXAMEDIA]["accounts"][email].get(
         "login_obj",
         AlexaLogin(
@@ -768,7 +871,7 @@ async def async_setup_entry(hass, config_entry):
             outputpath=hass.config.path,
             debug=account.get(CONF_DEBUG),
             otp_secret=account.get(CONF_OTPSECRET, ""),
-            oauth=account.get(CONF_OAUTH, {}),
+            oauth=secure_oauth,
             uuid=uuid,
             oauth_login=True,
         ),
@@ -791,7 +894,9 @@ async def async_setup_entry(hass, config_entry):
     hass.bus.async_listen("alexa_media_relogin_success", login_success)
     try:
         _t = time.monotonic()
-        cookies = await login.load_cookie()
+        # Secure entries never read a legacy cookie file — the session is
+        # reconstructed from the stored refresh token on every start.
+        cookies = None if secure else await login.load_cookie()
         cookie_login_ok = False
         if cookies:
             try:
@@ -824,11 +929,21 @@ async def async_setup_entry(hass, config_entry):
             except (JSONDecodeError, ValueError, aiohttp.ClientError) as ex:
                 _LOGGER.debug("[BOOT] Bootstrap cookie auth check failed: %s", ex)
         if not cookie_login_ok:
-            await login.login(cookies=cookies)
+            try:
+                await login.login(cookies=cookies)
+            except AuthTerminalError as err:
+                # The stored device registration is dead — only interactive
+                # re-enrollment can recover it.
+                raise ConfigEntryAuthFailed(str(err)) from err
         _LOGGER.debug("[BOOT] login completed in %.2fs", time.monotonic() - _t)
         _t = time.monotonic()
         if await test_login_status(hass, config_entry, login):
             _LOGGER.debug("[BOOT] test_login_status in %.2fs", time.monotonic() - _t)
+            if secure and secure_store is not None:
+                # First successful round-trip commits the migrated/enrolled
+                # credentials and drains any legacy secrets from the entry.
+                await secure_store.async_mark_validated()
+                await _cleanup_legacy_secrets(hass, config_entry)
             _t = time.monotonic()
             await setup_alexa(hass, config_entry, login)
             _LOGGER.debug(
@@ -1365,22 +1480,37 @@ async def setup_alexa(hass, config_entry, login_obj: AlexaLogin):
                     device_entry.name,
                 )
 
-        await login_obj.save_cookiefile()
-        if login_obj.access_token:
-            hass.config_entries.async_update_entry(
-                config_entry,
-                data={
-                    **config_entry.data,
-                    CONF_OAUTH: {
-                        "access_token": login_obj.access_token,
+        if config_entry.data.get(CONF_SECURE):
+            # Persist only rotated durable credentials, and only to the
+            # protected store — never write tokens back into the config entry.
+            if login_obj.refresh_token:
+                store = SecureCredentialStore(hass, config_entry.entry_id)
+                stored = await store.async_load() or {}
+                await store.async_save(
+                    {
+                        **stored,
                         "refresh_token": login_obj.refresh_token,
-                        "expires_in": login_obj.expires_in,
                         "mac_dms": login_obj.mac_dms,
-                        "code_verifier": login_obj.code_verifier,
-                        "authorization_code": login_obj.authorization_code,
                     },
-                },
-            )
+                    pending_validation=False,
+                )
+        else:
+            await login_obj.save_cookiefile()
+            if login_obj.access_token:
+                hass.config_entries.async_update_entry(
+                    config_entry,
+                    data={
+                        **config_entry.data,
+                        CONF_OAUTH: {
+                            "access_token": login_obj.access_token,
+                            "refresh_token": login_obj.refresh_token,
+                            "expires_in": login_obj.expires_in,
+                            "mac_dms": login_obj.mac_dms,
+                            "code_verifier": login_obj.code_verifier,
+                            "authorization_code": login_obj.authorization_code,
+                        },
+                    },
+                )
 
         if first_run or not _push_healthy(account):
             if _network_allowed(login_obj):
@@ -3147,6 +3277,43 @@ async def async_remove_entry(hass, entry) -> bool:
     email = entry.data["email"]
     obfuscated_email = hide_email(email)
     _LOGGER.debug("Removing config entry: %s", hide_email(email))
+
+    if entry.data.get(CONF_SECURE):
+        # Best-effort device deregistration, then delete the protected store.
+        # Amazon availability must never block entry removal.
+        store = SecureCredentialStore(hass, entry.entry_id)
+        creds = await store.async_load()
+        if creds and creds.get("refresh_token"):
+            try:
+                from alexapy import (  # pylint: disable=import-outside-toplevel
+                    DeviceCredentials,
+                    TokenManager,
+                )
+
+                manager = TokenManager(
+                    DeviceCredentials(
+                        refresh_token=creds["refresh_token"],
+                        mac_dms=creds.get("mac_dms") or {},
+                        serial=creds.get("serial", ""),
+                        customer_id=creds.get("customer_id"),
+                        domain=creds.get("domain", "amazon.com"),
+                    )
+                )
+                async with aiohttp.ClientSession() as session:
+                    await manager.async_refresh_access_token(session)
+                    await manager.async_deregister(session)
+                _LOGGER.debug("Deregistered device for %s", obfuscated_email)
+            except Exception as ex:  # noqa: BLE001
+                _LOGGER.debug(
+                    "Best-effort deregister failed for %s: %s", obfuscated_email, ex
+                )
+        try:
+            await store.async_remove()
+        except Exception as ex:  # noqa: BLE001
+            _LOGGER.debug("Could not remove secure store: %s", ex)
+        _LOGGER.debug("Config entry %s removed.", obfuscated_email)
+        return True
+
     login_obj = AlexaLogin(
         url="",
         email=email,
@@ -3275,15 +3442,15 @@ async def test_login_status(hass, config_entry, login) -> bool:
         context={"source": SOURCE_REAUTH},
         data={
             CONF_EMAIL: account[CONF_EMAIL],
-            CONF_PASSWORD: account[CONF_PASSWORD],
+            CONF_PASSWORD: account.get(CONF_PASSWORD, ""),
             CONF_URL: account[CONF_URL],
-            CONF_DEBUG: account[CONF_DEBUG],
-            CONF_INCLUDE_DEVICES: account[CONF_INCLUDE_DEVICES],
-            CONF_EXCLUDE_DEVICES: account[CONF_EXCLUDE_DEVICES],
+            CONF_DEBUG: account.get(CONF_DEBUG, False),
+            CONF_INCLUDE_DEVICES: account.get(CONF_INCLUDE_DEVICES, ""),
+            CONF_EXCLUDE_DEVICES: account.get(CONF_EXCLUDE_DEVICES, ""),
             CONF_SCAN_INTERVAL: (
                 account[CONF_SCAN_INTERVAL].total_seconds()
-                if isinstance(account[CONF_SCAN_INTERVAL], timedelta)
-                else account[CONF_SCAN_INTERVAL]
+                if isinstance(account.get(CONF_SCAN_INTERVAL), timedelta)
+                else account.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
             ),
             CONF_OTPSECRET: account.get(CONF_OTPSECRET, ""),
         },

--- a/custom_components/alexa_media/__init__.py
+++ b/custom_components/alexa_media/__init__.py
@@ -23,7 +23,11 @@ from alexapy import (
     AlexaLogin,
     AlexapyConnectionError,
     AlexapyLoginError,
+    AuthTerminalError,
+    AuthTransientError,
+    DeviceCredentials,
     HTTP2EchoClient,
+    TokenManager,
     __version__ as alexapy_version,
     hide_serial,
     obfuscate,
@@ -893,6 +897,33 @@ async def async_setup_entry(hass, config_entry):
     hass.bus.async_listen("alexa_media_relogin_success", login_success)
     try:
         _t = time.monotonic()
+        if secure:
+            # Preflight the stored credentials through TokenManager, which
+            # classifies failures precisely: AuthTransientError (network/5xx/429)
+            # -> retry via ConfigEntryNotReady; AuthTerminalError (revoked/invalid
+            # grant) -> ConfigEntryAuthFailed and the paste-URL reauth flow. This
+            # is the terminal-vs-transient contract the design promises, and it
+            # proves the protected-store token actually works before any legacy
+            # cleanup. AlexaLogin's own refresh returns False on transient errors,
+            # so relying on it alone would misclassify a blip as terminal.
+            preflight_creds = DeviceCredentials(
+                refresh_token=stored["refresh_token"],
+                mac_dms=stored.get("mac_dms") or {},
+                serial=stored.get("serial", ""),
+                customer_id=stored.get("customer_id"),
+                domain=stored.get("domain", url or "amazon.com"),
+            )
+            try:
+                async with aiohttp.ClientSession() as _pf_session:
+                    manager = TokenManager(preflight_creds)
+                    await manager.async_refresh_access_token(_pf_session)
+                    await manager.async_exchange_cookies(_pf_session)
+            except AuthTransientError as err:
+                raise ConfigEntryNotReady(
+                    f"Transient error refreshing Alexa credentials: {err}"
+                ) from err
+            except AuthTerminalError as err:
+                raise ConfigEntryAuthFailed(str(err)) from err
         # Secure entries never read a legacy cookie file — the session is
         # reconstructed from the stored refresh token on every start.
         cookies = None if secure else await login.load_cookie()
@@ -3320,16 +3351,29 @@ async def async_remove_entry(hass, entry) -> bool:
         try:
             await store.async_remove()
         except Exception as ex:  # noqa: BLE001
-            # Do not hide this: a leftover store still holds a replayable refresh
-            # token. Surface it at error level with the path so it can be removed
-            # manually; deregistration above already best-effort revoked it.
-            _LOGGER.error(
-                "Failed to delete secure credential store for %s (%s). A refresh "
-                "token may remain in .storage/%s — delete it manually.",
-                obfuscated_email,
-                ex,
-                store.key,
-            )
+            # A leftover store still holds a replayable refresh token. Try a
+            # direct file delete as a fallback, then surface loudly if even that
+            # fails so it can be removed manually (deregistration above already
+            # best-effort revoked it).
+            store_path = hass.config.path(".storage", store.key)
+            try:
+                if os.path.exists(store_path):
+                    os.remove(store_path)
+                    _LOGGER.warning(
+                        "Secure store delete failed via Store (%s); removed the "
+                        "file directly at %s.",
+                        ex,
+                        store_path,
+                    )
+            except OSError as file_ex:
+                _LOGGER.error(
+                    "Could not delete secure credential store for %s (%s / %s). A "
+                    "refresh token may remain at %s — delete it manually.",
+                    obfuscated_email,
+                    ex,
+                    file_ex,
+                    store_path,
+                )
         _LOGGER.debug("Config entry %s removed.", obfuscated_email)
         return True
 

--- a/custom_components/alexa_media/__init__.py
+++ b/custom_components/alexa_media/__init__.py
@@ -60,7 +60,6 @@ import voluptuous as vol
 
 from .alexa_entity import AlexaEntityData, get_entity_data, parse_alexa_entities
 from .config_flow import CONFIG_VERSION, in_progress_instances
-from .secure_store import SecureCredentialStore
 from .const import (
     ALEXA_COMPONENTS,
     CONF_ACCOUNTS,
@@ -120,6 +119,7 @@ from .helpers import (
 from .metrics import AlexaMetrics, get_metrics
 from .notify import async_unload_entry as notify_async_unload_entry
 from .runtime_data import AlexaRuntimeData
+from .secure_store import SecureCredentialStore
 from .services import AlexaMediaServices
 
 _LOGGER = logging.getLogger(__name__)

--- a/custom_components/alexa_media/__init__.py
+++ b/custom_components/alexa_media/__init__.py
@@ -970,8 +970,14 @@ async def async_setup_entry(hass, config_entry):
             # ConfigEntryAuthFailed to start the paste-URL reauth flow — this is
             # the terminal-vs-transient classification the design promises.
             if not (login.status and login.status.get("login_successful")):
-                raise ConfigEntryAuthFailed(
-                    "Stored device credentials were rejected; re-enrollment required"
+                # The TokenManager preflight above already proved the stored
+                # token is valid and classified terminal failures. If AlexaLogin
+                # still fails to reach a logged-in state here, it is a
+                # second-bootstrap hiccup, not a dead registration — retry rather
+                # than force reauth.
+                raise ConfigEntryNotReady(
+                    "Alexa login did not complete after a successful credential "
+                    "refresh; will retry"
                 )
             if secure_store is not None:
                 # First successful refresh commits the migrated/enrolled

--- a/custom_components/alexa_media/config_flow.py
+++ b/custom_components/alexa_media/config_flow.py
@@ -152,12 +152,15 @@ class AlexaMediaFlowHandler(config_entries.ConfigFlow):
         if not creds.customer_id:
             _LOGGER.debug("Registration returned no account id; rejecting")
             return self._paste_form("register_failed")
-        # Validate the freshly minted credentials before persisting anything, so
-        # a bad registration cannot overwrite a working store (reauth) or create
-        # a dead entry.
+        # Validate the freshly minted credentials with the full runtime round
+        # trip (access-token refresh + cookie mint) before persisting anything,
+        # so a bad registration cannot overwrite a working store (reauth) or
+        # create a dead entry.
         try:
             async with aiohttp.ClientSession() as session:
-                await TokenManager(creds).async_refresh_access_token(session)
+                manager = TokenManager(creds)
+                await manager.async_refresh_access_token(session)
+                await manager.async_exchange_cookies(session)
         except AuthTerminalError as err:
             _LOGGER.debug("New credentials rejected on validation: %s", err)
             return self._paste_form("register_failed")
@@ -185,6 +188,15 @@ class AlexaMediaFlowHandler(config_entries.ConfigFlow):
             existing_uid = existing_entry.unique_id or ""
             if existing_uid.startswith("amzn1.account"):
                 self._abort_if_unique_id_mismatch(reason="wrong_account")
+            else:
+                # Rebinding a legacy entry must not collide with a different
+                # entry that already owns this account id.
+                for other in self.hass.config_entries.async_entries(DOMAIN):
+                    if (
+                        other.entry_id != existing_entry.entry_id
+                        and other.unique_id == creds.customer_id
+                    ):
+                        return self.async_abort(reason="already_configured")
         else:
             self._abort_if_unique_id_configured()
 

--- a/custom_components/alexa_media/config_flow.py
+++ b/custom_components/alexa_media/config_flow.py
@@ -3,85 +3,55 @@ Alexa Config Flow.
 
 SPDX-License-Identifier: Apache-2.0
 
+Secure enrollment (RFC #3523): the user authenticates on Amazon's own login
+page in their browser (paste-URL flow, no proxy) and pastes the resulting
+redirect URL back. Only the minimized device credentials are persisted, and
+they live in a dedicated protected store — never the password or a TOTP seed.
+
 For more details about this platform, please refer to the documentation at
 https://community.home-assistant.io/t/echo-devices-alexa-as-media-player-testers-needed/58639
 """
 
-from asyncio import sleep
 from collections import OrderedDict
-import datetime
-from datetime import timedelta
-from functools import reduce
-import html as html_lib
 import logging
 from typing import Any, Optional
-from urllib.parse import urlparse
 
-from aiohttp import ClientConnectionError, ClientSession, InvalidURL, web, web_response
-from aiohttp.web_exceptions import HTTPBadRequest
-from alexapy import (
-    AlexaLogin,
-    AlexaProxy,
-    AlexapyConnectionError,
-    AlexapyPyotpInvalidKey,
-    hide_email,
-    obfuscate,
-)
+import aiohttp
+from alexapy import EnrollmentError, EnrollmentFlow, hide_email, obfuscate
 from awesomeversion import AwesomeVersion
 from homeassistant import config_entries
-from homeassistant.components.http.view import HomeAssistantView
-from homeassistant.components.persistent_notification import (
-    async_dismiss as async_dismiss_persistent_notification,
-)
 from homeassistant.const import (
     CONF_EMAIL,
-    CONF_PASSWORD,
     CONF_SCAN_INTERVAL,
     CONF_URL,
     __version__ as HAVERSION,
 )
 from homeassistant.core import callback
-from homeassistant.data_entry_flow import FlowResult, UnknownFlow
-from homeassistant.exceptions import Unauthorized
-from homeassistant.helpers.httpx_client import create_async_httpx_client
-from homeassistant.helpers.network import NoURLAvailableError, get_url
-from homeassistant.util import slugify
-import httpx
+from homeassistant.data_entry_flow import FlowResult
 import voluptuous as vol
-from yarl import URL
 
 from .const import (
-    AUTH_CALLBACK_NAME,
-    AUTH_CALLBACK_PATH,
-    AUTH_PROXY_NAME,
-    AUTH_PROXY_PATH,
     CONF_DEBUG,
     CONF_EXCLUDE_DEVICES,
     CONF_EXTENDED_ENTITY_DISCOVERY,
-    CONF_HASS_URL,
     CONF_INCLUDE_DEVICES,
     CONF_OAUTH,
-    CONF_OTPSECRET,
-    CONF_PROXY_WARNING,
+    CONF_PASTE_URL,
     CONF_PUBLIC_URL,
     CONF_QUEUE_DELAY,
-    CONF_SECURITYCODE,
-    CONF_TOTP_REGISTER,
-    DATA_ALEXAMEDIA,
+    CONF_SECURE,
     DEFAULT_DEBUG,
     DEFAULT_EXTENDED_ENTITY_DISCOVERY,
-    DEFAULT_HASS_URL,
     DEFAULT_PUBLIC_URL,
     DEFAULT_QUEUE_DELAY,
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
-    ISSUE_URL,
 )
-from .helpers import calculate_uuid
+from .secure_store import SecureCredentialStore
 
 _LOGGER = logging.getLogger(__name__)
 
-CONFIG_VERSION = 1
+CONFIG_VERSION = 2
 
 
 @callback
@@ -96,157 +66,200 @@ def in_progress_instances(hass):
     return {
         entry["flow_id"]
         for entry in hass.config_entries.flow.async_progress()
-        if entry["handler"] == DOMAIN  # Ensure only Alexa Media flows are included
+        if entry["handler"] == DOMAIN
     }
 
 
 @config_entries.HANDLERS.register(DOMAIN)
 class AlexaMediaFlowHandler(config_entries.ConfigFlow):
-    """Handle a Alexa Media config flow."""
+    """Handle an Alexa Media config flow.
+
+    Enrollment is a two-step, credential-minimizing flow: collect the account
+    label and region, then have the user log in on Amazon's own page and paste
+    back the redirect URL. The password and any MFA are handled entirely by
+    Amazon; nothing but the derived device credentials is ever stored.
+    """
 
     VERSION = CONFIG_VERSION
 
     CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_POLL
-    proxy: AlexaProxy = None
-    proxy_view: "AlexaMediaAuthorizationProxyView" = None
-
-    def _update_ord_dict(self, old_dict: OrderedDict, new_dict: dict) -> OrderedDict:
-        result: OrderedDict = OrderedDict()
-        for k, v in old_dict.items():  # pylint: disable=invalid-name
-            for key, value in new_dict.items():
-                if k == key:
-                    result.update([(key, value)])
-                    break
-            if k not in result:
-                result.update([(k, v)])
-        return result
 
     def __init__(self):
         """Initialize the config flow."""
-        self.login = None
-        self.securitycode: Optional[str] = None
-        self.automatic_steps: int = 0
-        self.config = OrderedDict()
-        self.proxy_schema = None
-        self.data_schema = OrderedDict(
-            [
-                (vol.Required(CONF_URL, default="amazon.com"), str),
-                (vol.Required(CONF_HASS_URL), str),
-                (vol.Required(CONF_EMAIL), str),
-                (vol.Required(CONF_PASSWORD), str),
-                (vol.Optional(CONF_OTPSECRET), str),
-                (vol.Optional(CONF_SECURITYCODE), str),
-                (vol.Optional(CONF_PUBLIC_URL), str),
-                (vol.Optional(CONF_INCLUDE_DEVICES, default=""), str),
-                (vol.Optional(CONF_EXCLUDE_DEVICES, default=""), str),
-                (vol.Optional(CONF_SCAN_INTERVAL, default=60), int),
-                (vol.Optional(CONF_QUEUE_DELAY, default=1.5), float),
-                (vol.Optional(CONF_EXTENDED_ENTITY_DISCOVERY, default=False), bool),
-                (vol.Optional(CONF_DEBUG, default=False), bool),
-            ]
-        )
-        self.totp_register = OrderedDict(
-            [(vol.Optional(CONF_TOTP_REGISTER, default=False), bool)]
-        )
-        self.proxy_warning = OrderedDict(
-            [(vol.Optional(CONF_PROXY_WARNING, default=False), bool)]
-        )
-
-    async def async_step_import(self, import_config):
-        """Import a config entry from configuration.yaml."""
-        return await self.async_step_user_legacy(import_config)
+        self.config: OrderedDict = OrderedDict()
+        self._enrollment: Optional[EnrollmentFlow] = None
 
     async def async_step_user(self, user_input=None):
-        # pylint: disable=too-many-branches
+        """Step 1: collect the account label + region, then show the login URL.
 
-        """Provide a proxy for login."""
+        No password or TOTP seed is entered here or stored. See
+        https://github.com/superbeetle1973/alexa-auth-redesign
+        """
         self._save_user_input_to_config(user_input=user_input)
-        """ Internal URL for proxy authentication """
-        try:
-            hass_url: str = get_url(self.hass, allow_external=False)
-        except NoURLAvailableError:
-            hass_url = DEFAULT_HASS_URL
+        reauth = bool(self.config.get("reauth"))
+        if not user_input or not self.config.get(CONF_EMAIL):
+            return self.async_show_form(
+                step_id="user",
+                data_schema=vol.Schema(self._user_schema()),
+                description_placeholders={"message": "REAUTH" if reauth else ""},
+            )
+        self._enrollment = EnrollmentFlow(domain=self.config[CONF_URL])
+        return self.async_show_form(
+            step_id="paste",
+            data_schema=vol.Schema({vol.Required(CONF_PASTE_URL): str}),
+            description_placeholders={
+                "url": self._enrollment.oauth_url,
+                "email": self.config[CONF_EMAIL],
+            },
+        )
 
-        """ External URL for cloud connected services """
+    async def async_step_paste(self, user_input=None):
+        """Step 2: accept the pasted maplanding URL and register the device."""
+        if self._enrollment is None:
+            return await self.async_step_user()
+        if not user_input or not user_input.get(CONF_PASTE_URL):
+            return self._paste_form("paste_required")
         try:
-            url: str = get_url(self.hass, allow_internal=False)
-        except NoURLAvailableError:
-            DEFAULT_PUBLIC_URL = ""
-        else:
-            DEFAULT_PUBLIC_URL = url if url.endswith("/") else url + "/"
+            code = self._enrollment.parse_redirect_url(user_input[CONF_PASTE_URL])
+        except EnrollmentError as err:
+            _LOGGER.debug("Paste-URL rejected: %s", err)
+            return self._paste_form("paste_invalid")
+        try:
+            async with aiohttp.ClientSession() as session:
+                creds = await self._enrollment.async_register(session, code)
+        except EnrollmentError as err:
+            _LOGGER.debug("Device registration failed: %s", err)
+            return self._paste_form("register_failed")
+        return await self._finish_secure_enrollment(creds)
 
-        self.proxy_schema = OrderedDict(
+    async def _finish_secure_enrollment(self, creds) -> FlowResult:
+        """Persist only the durable device credentials — no password/seed.
+
+        Binds the config entry to the Amazon account id returned by the
+        exchange so a reauth can never silently rebind to a different account.
+        """
+        email = self.config[CONF_EMAIL]
+        url = self.config[CONF_URL]
+        existing_entry = self._reauth_entry()
+
+        if creds.customer_id:
+            await self.async_set_unique_id(creds.customer_id)
+            if existing_entry:
+                self._abort_if_unique_id_mismatch(reason="wrong_account")
+            else:
+                self._abort_if_unique_id_configured()
+
+        # The config entry never holds secrets; the minimized device credentials
+        # go to the dedicated protected store.
+        self.config[CONF_SECURE] = True
+        self.config.pop(CONF_OAUTH, None)
+        self.config.pop("reauth", None)
+        self.config.setdefault(CONF_DEBUG, DEFAULT_DEBUG)
+        self.config.setdefault(CONF_INCLUDE_DEVICES, "")
+        self.config.setdefault(CONF_EXCLUDE_DEVICES, "")
+        self.config.setdefault(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
+        self.config.setdefault(CONF_QUEUE_DELAY, DEFAULT_QUEUE_DELAY)
+        self.config.setdefault(CONF_PUBLIC_URL, DEFAULT_PUBLIC_URL)
+        self.config.setdefault(
+            CONF_EXTENDED_ENTITY_DISCOVERY, DEFAULT_EXTENDED_ENTITY_DISCOVERY
+        )
+        self._enrollment = None
+
+        if existing_entry:
+            store = SecureCredentialStore(self.hass, existing_entry.entry_id)
+            await store.async_save(creds.as_dict(), pending_validation=False)
+            self.hass.config_entries.async_update_entry(
+                existing_entry, data=self.config
+            )
+            await self.hass.config_entries.async_reload(existing_entry.entry_id)
+            _LOGGER.debug("Secure reauth successful for %s", hide_email(email))
+            return self.async_abort(reason="reauth_successful")
+
+        # New entry: create it first so we have an entry_id, then attach creds.
+        result = self.async_create_entry(title=f"{email} - {url}", data=self.config)
+        created = result.get("result")
+        if created is not None:
+            store = SecureCredentialStore(self.hass, created.entry_id)
+            await store.async_save(creds.as_dict(), pending_validation=False)
+        return result
+
+    async def async_step_reauth(self, user_input=None):
+        """Handle reauth: re-enroll interactively via the paste-URL flow.
+
+        A dead refresh token cannot be recovered unattended — it requires a
+        person to log in through Amazon again (the design's product contract),
+        so route straight to the secure enrollment form.
+        """
+        self._save_user_input_to_config(user_input)
+        self.config["reauth"] = True
+        self._enrollment = None
+        _LOGGER.debug("Creating reauth form with %s", obfuscate(self.config))
+        return await self.async_step_user()
+
+    def _reauth_entry(self):
+        """Return the entry being reauthenticated, if any."""
+        if self.source != config_entries.SOURCE_REAUTH:
+            return None
+        get_entry = getattr(self, "_get_reauth_entry", None)
+        if callable(get_entry):
+            try:
+                return get_entry()
+            except Exception:  # noqa: BLE001  # pragma: no cover
+                return None
+        entry_id = self.context.get("entry_id")
+        if entry_id:
+            return self.hass.config_entries.async_get_entry(entry_id)
+        return None
+
+    def _paste_form(self, error_key: str) -> FlowResult:
+        return self.async_show_form(
+            step_id="paste",
+            data_schema=vol.Schema({vol.Required(CONF_PASTE_URL): str}),
+            errors={"base": error_key},
+            description_placeholders={
+                "url": self._enrollment.oauth_url if self._enrollment else "",
+                "email": self.config.get(CONF_EMAIL, ""),
+            },
+        )
+
+    def _user_schema(self) -> OrderedDict:
+        cfg = self.config
+        return OrderedDict(
             [
-                (
-                    vol.Required(
-                        CONF_URL, default=self.config.get(CONF_URL, "amazon.com")
-                    ),
-                    str,
-                ),
-                (
-                    vol.Required(CONF_EMAIL, default=self.config.get(CONF_EMAIL, "")),
-                    str,
-                ),
-                (
-                    vol.Required(
-                        CONF_PASSWORD, default=self.config.get(CONF_PASSWORD, "")
-                    ),
-                    str,
-                ),
-                (
-                    vol.Optional(
-                        CONF_OTPSECRET, default=self.config.get(CONF_OTPSECRET, "")
-                    ),
-                    str,
-                ),
-                (
-                    vol.Optional(
-                        CONF_HASS_URL,
-                        default=self.config.get(CONF_HASS_URL, hass_url),
-                    ),
-                    str,
-                ),
-                (
-                    vol.Optional(
-                        CONF_PUBLIC_URL,
-                        default=self.config.get(CONF_PUBLIC_URL, DEFAULT_PUBLIC_URL),
-                    ),
-                    str,
-                ),
+                (vol.Required(CONF_EMAIL, default=cfg.get(CONF_EMAIL, "")), str),
+                (vol.Required(CONF_URL, default=cfg.get(CONF_URL, "amazon.com")), str),
                 (
                     vol.Optional(
                         CONF_INCLUDE_DEVICES,
-                        default=self.config.get(CONF_INCLUDE_DEVICES, ""),
+                        default=cfg.get(CONF_INCLUDE_DEVICES, ""),
                     ),
                     str,
                 ),
                 (
                     vol.Optional(
                         CONF_EXCLUDE_DEVICES,
-                        default=self.config.get(CONF_EXCLUDE_DEVICES, ""),
+                        default=cfg.get(CONF_EXCLUDE_DEVICES, ""),
                     ),
                     str,
                 ),
                 (
                     vol.Optional(
                         CONF_SCAN_INTERVAL,
-                        default=self.config.get(
-                            CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL
-                        ),
+                        default=cfg.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL),
                     ),
                     int,
                 ),
                 (
                     vol.Optional(
                         CONF_QUEUE_DELAY,
-                        default=self.config.get(CONF_QUEUE_DELAY, DEFAULT_QUEUE_DELAY),
+                        default=cfg.get(CONF_QUEUE_DELAY, DEFAULT_QUEUE_DELAY),
                     ),
                     float,
                 ),
                 (
                     vol.Optional(
                         CONF_EXTENDED_ENTITY_DISCOVERY,
-                        default=self.config.get(
+                        default=cfg.get(
                             CONF_EXTENDED_ENTITY_DISCOVERY,
                             DEFAULT_EXTENDED_ENTITY_DISCOVERY,
                         ),
@@ -255,658 +268,38 @@ class AlexaMediaFlowHandler(config_entries.ConfigFlow):
                 ),
                 (
                     vol.Optional(
-                        CONF_DEBUG, default=self.config.get(CONF_DEBUG, DEFAULT_DEBUG)
+                        CONF_DEBUG, default=cfg.get(CONF_DEBUG, DEFAULT_DEBUG)
                     ),
                     bool,
                 ),
             ]
         )
-        if not user_input:
-            return self.async_show_form(
-                step_id="user",
-                data_schema=vol.Schema(self.proxy_schema),
-                description_placeholders={"message": ""},
-            )
-        if self.login is None:
-            try:
-                self.login = self.hass.data[DATA_ALEXAMEDIA]["accounts"][
-                    self.config[CONF_EMAIL]
-                ].get("login_obj")
-            except KeyError:
-                self.login = None
-        try:
-            if not self.login or self.login.session.closed:
-                _LOGGER.debug("Creating new login")
-                uuid_dict = await calculate_uuid(
-                    self.hass, self.config.get(CONF_EMAIL), self.config[CONF_URL]
-                )
-                uuid = uuid_dict["uuid"]
-                self.login = AlexaLogin(
-                    url=self.config[CONF_URL],
-                    email=self.config.get(CONF_EMAIL, ""),
-                    password=self.config.get(CONF_PASSWORD, ""),
-                    outputpath=self.hass.config.path,
-                    debug=self.config[CONF_DEBUG],
-                    otp_secret=self.config.get(CONF_OTPSECRET, ""),
-                    oauth=self.config.get(CONF_OAUTH, {}),
-                    uuid=uuid,
-                    oauth_login=True,
-                )
-            else:
-                _LOGGER.debug("Using existing login")
-                if self.config.get(CONF_EMAIL):
-                    self.login.email = self.config.get(CONF_EMAIL)
-                if self.config.get(CONF_PASSWORD):
-                    self.login.password = self.config.get(CONF_PASSWORD)
-                if self.config.get(CONF_OTPSECRET):
-                    self.login.set_totp(self.config.get(CONF_OTPSECRET, ""))
-        except AlexapyPyotpInvalidKey:
-            return self.async_show_form(
-                step_id="user",
-                data_schema=vol.Schema(self.proxy_schema),
-                errors={"base": "2fa_key_invalid"},
-                description_placeholders={
-                    "otp_secret": self.config.get(CONF_OTPSECRET, ""),
-                },
-            )
-        hass_url: str = user_input.get(CONF_HASS_URL)
-        if hass_url is None:
-            try:
-                hass_url = get_url(self.hass, prefer_external=True)
-            except NoURLAvailableError:
-                _LOGGER.debug(
-                    "No Home Assistant URL found in config or detected; forcing user form"
-                )
-                return self.async_show_form(
-                    step_id="user",
-                    data_schema=vol.Schema(self.proxy_schema),
-                    description_placeholders={"message": ""},
-                )
-        hass_url_valid: bool = False
-        hass_url_error: str = ""
-        async with ClientSession() as session:
-            try:
-                async with session.get(hass_url) as resp:
-                    hass_url_valid = resp.status == 200
-            except ClientConnectionError as err:
-                hass_url_valid = False
-                hass_url_error = str(err)
-            except InvalidURL as err:
-                hass_url_valid = False
-                hass_url_error = str(err.__cause__)
-        if not hass_url_valid:
-            _LOGGER.debug(
-                "Unable to connect to provided Home Assistant url: %s", hass_url
-            )
-            return self.async_show_form(
-                step_id="proxy_warning",
-                data_schema=vol.Schema(self.proxy_warning),
-                errors={},
-                description_placeholders={
-                    "email": self.login.email,
-                    "hass_url": hass_url,
-                    "error": hass_url_error,
-                },
-            )
-        if (
-            user_input
-            and user_input.get(CONF_OTPSECRET)
-            and user_input.get(CONF_OTPSECRET).replace(" ", "")
-        ):
-            otp: str = self.login.get_totp_token()
-            if otp:
-                _LOGGER.debug("Generated TOTP: %s", otp)
-                return self.async_show_form(
-                    step_id="totp_register",
-                    data_schema=vol.Schema(self.totp_register),
-                    errors={},
-                    description_placeholders={
-                        "email": self.login.email,
-                        "url": self.login.url,
-                        "message": otp,
-                    },
-                )
-        return await self.async_step_start_proxy(user_input)
-
-    async def async_step_start_proxy(self, user_input=None):
-        """Start proxy for login."""
-        # pylint: disable=unused-argument
-        _LOGGER.debug(
-            "Starting proxy for %s - %s",
-            hide_email(self.login.email),
-            self.login.url,
-        )
-        if not self.proxy:
-            try:
-                self.proxy = AlexaProxy(
-                    self.login,
-                    str(URL(self.config.get(CONF_HASS_URL)).with_path(AUTH_PROXY_PATH)),
-                )
-                self.proxy.session_factory = lambda: create_async_httpx_client(
-                    self.hass,
-                    verify_ssl=True,
-                    follow_redirects=False,
-                    timeout=httpx.Timeout(
-                        connect=30.0,
-                        read=120.0,
-                        write=30.0,
-                        pool=30.0,
-                    ),
-                )
-            except ValueError as ex:
-                return self.async_show_form(
-                    step_id="user",
-                    errors={"base": "invalid_url"},
-                    description_placeholders={"message": str(ex)},
-                )
-        # Swap the login object
-        self.proxy.change_login(self.login)
-        # Increase timeout for Amazon authentication (default 5s is too short)
-        if hasattr(self.proxy, "session") and self.proxy.session:
-            self.proxy.session.timeout = httpx.Timeout(
-                connect=30.0,
-                read=120.0,
-                write=30.0,
-                pool=30.0,
-            )
-            _LOGGER.debug(
-                "Proxy session timeout set to: %s",
-                self.proxy.session.timeout,
-            )
-        else:
-            _LOGGER.warning(
-                "Proxy: No session found on proxy object. Attrs: %s",
-                dir(self.proxy),
-            )
-        if not self.proxy_view:
-            self.proxy_view = AlexaMediaAuthorizationProxyView(self.proxy.all_handler)
-        else:
-            _LOGGER.debug("Found existing proxy_view")
-            self.proxy_view.handler = self.proxy.all_handler
-        self.hass.http.register_view(AlexaMediaAuthorizationCallbackView())
-        self.hass.http.register_view(self.proxy_view)
-        callback_url = (
-            URL(self.config[CONF_HASS_URL])
-            .with_path(AUTH_CALLBACK_PATH)
-            .with_query({"flow_id": self.flow_id})
-        )
-
-        proxy_url = self.proxy.access_url().with_query(
-            {"config_flow_id": self.flow_id, "callback_url": str(callback_url)}
-        )
-        self.login._session.cookie_jar.clear()  # pylint: disable=protected-access
-        self.login.proxy_url = proxy_url
-        return self.async_external_step(step_id="check_proxy", url=str(proxy_url))
-
-    async def async_step_check_proxy(self, user_input=None):
-        # pylint: disable=unused-argument
-        """Check status of proxy for login."""
-        _LOGGER.debug(
-            "Checking proxy response for %s - %s",
-            hide_email(self.login.email),
-            self.login.url,
-        )
-        self.proxy_view.reset()
-        return self.async_external_step_done(next_step_id="finish_proxy")
-
-    async def async_step_finish_proxy(self, user_input=None):
-        # pylint: disable=unused-argument
-        """Finish auth."""
-        if await self.login.test_loggedin():
-            await self.login.finalize_login()
-            self.config[CONF_EMAIL] = self.login.email
-            self.config[CONF_PASSWORD] = self.login.password
-            return await self._test_login()
-        return self.async_abort(reason="login_failed")
-
-    async def async_step_user_legacy(self, user_input=None):
-        """Handle legacy input for the config flow."""
-        # pylint: disable=too-many-return-statements
-        self._save_user_input_to_config(user_input=user_input)
-        self.data_schema = self._update_schema_defaults()
-        if not user_input:
-            self.automatic_steps = 0
-            return self.async_show_form(
-                step_id="user",
-                data_schema=vol.Schema(self.data_schema),
-                description_placeholders={"message": ""},
-            )
-        if (
-            not self.config.get("reauth")
-            and f"{self.config[CONF_EMAIL]} - {self.config[CONF_URL]}"
-            in configured_instances(self.hass)
-            and not self.hass.data[DATA_ALEXAMEDIA]["config_flows"].get(
-                f"{self.config[CONF_EMAIL]} - {self.config[CONF_URL]}"
-            )
-        ):
-            _LOGGER.debug("Existing account found")
-            self.automatic_steps = 0
-            return self.async_show_form(
-                step_id="user",
-                data_schema=vol.Schema(self.data_schema),
-                errors={CONF_EMAIL: "identifier_exists"},
-                description_placeholders={"message": ""},
-            )
-        if self.login is None:
-            try:
-                self.login = self.hass.data[DATA_ALEXAMEDIA]["accounts"][
-                    self.config[CONF_EMAIL]
-                ].get("login_obj")
-            except KeyError:
-                self.login = None
-        try:
-            if not self.login or self.login.session.closed:
-                _LOGGER.debug("Creating new login")
-                uuid_dict = await calculate_uuid(
-                    self.hass, self.config.get(CONF_EMAIL), self.config[CONF_URL]
-                )
-                uuid = uuid_dict["uuid"]
-                self.login = AlexaLogin(
-                    url=self.config[CONF_URL],
-                    email=self.config[CONF_EMAIL],
-                    password=self.config[CONF_PASSWORD],
-                    outputpath=self.hass.config.path,
-                    debug=self.config[CONF_DEBUG],
-                    otp_secret=self.config.get(CONF_OTPSECRET, ""),
-                    uuid=uuid,
-                    oauth_login=True,
-                )
-            else:
-                _LOGGER.debug("Using existing login")
-            if (
-                not self.config.get("reauth")
-                and user_input
-                and user_input.get(CONF_OTPSECRET)
-                and user_input.get(CONF_OTPSECRET).replace(" ", "")
-            ):
-                otp: str = self.login.get_totp_token()
-                if otp:
-                    _LOGGER.debug("Generated TOTP: %s", otp)
-                    return self.async_show_form(
-                        step_id="totp_register",
-                        data_schema=vol.Schema(self.totp_register),
-                        errors={},
-                        description_placeholders={
-                            "email": self.login.email,
-                            "url": self.login.url,
-                            "message": otp,
-                        },
-                    )
-                return self.async_show_form(
-                    step_id="user",
-                    errors={"base": "2fa_key_invalid"},
-                    description_placeholders={
-                        "otp_secret": user_input.get(CONF_OTPSECRET),
-                    },
-                )
-            if self.login.status:
-                _LOGGER.debug("Resuming existing flow")
-                return await self._test_login()
-            _LOGGER.debug("Trying to login %s", self.login.status)
-            await self.login.login(
-                data=self.config,
-            )
-            return await self._test_login()
-        except AlexapyConnectionError:
-            self.automatic_steps = 0
-            return self.async_show_form(
-                step_id="user_legacy",
-                errors={"base": "connection_error"},
-                description_placeholders={"message": ""},
-            )
-        except AlexapyPyotpInvalidKey:
-            self.automatic_steps = 0
-            return self.async_show_form(
-                step_id="user_legacy",
-                errors={"base": "2fa_key_invalid"},
-                description_placeholders={
-                    "otp_secret": user_input.get(CONF_OTPSECRET),
-                },
-            )
-        except BaseException as ex:  # pylint: disable=broad-except
-            _LOGGER.warning("Unknown error: %s", ex)
-            if self.config[CONF_DEBUG]:
-                raise
-            self.automatic_steps = 0
-            return self.async_show_form(
-                step_id="user_legacy",
-                errors={"base": "unknown_error"},
-                description_placeholders={"message": str(ex)},
-            )
-
-    async def async_step_proxy_warning(self, user_input=None):
-        """Handle the proxy_warning for the config flow."""
-        self._save_user_input_to_config(user_input=user_input)
-        if user_input and user_input.get(CONF_PROXY_WARNING) is False:
-            _LOGGER.debug("User is not accepting warning, go back")
-            return self.async_show_form(
-                step_id="user",
-                data_schema=vol.Schema(self.proxy_schema),
-                description_placeholders={"message": ""},
-            )
-        _LOGGER.debug("User is ignoring proxy warning; starting proxy anyway")
-        return await self.async_step_start_proxy(user_input)
-
-    async def async_step_totp_register(self, user_input=None):
-        """Handle the input processing of the config flow."""
-        self._save_user_input_to_config(user_input=user_input)
-        if user_input and user_input.get(CONF_TOTP_REGISTER) is False:
-            _LOGGER.debug("Not registered, regenerating")
-            otp: str = self.login.get_totp_token()
-            if otp:
-                _LOGGER.debug("Generated TOTP: %s", otp)
-                return self.async_show_form(
-                    step_id="totp_register",
-                    data_schema=vol.Schema(self.totp_register),
-                    errors={},
-                    description_placeholders={
-                        "email": self.login.email,
-                        "url": self.login.url,
-                        "message": otp,
-                    },
-                )
-        return await self.async_step_start_proxy(user_input)
-
-    async def async_step_process(self, step_id, user_input=None):
-        """Handle the input processing of the config flow."""
-        _LOGGER.debug(
-            "Processing input for %s: %s",
-            step_id,
-            obfuscate(user_input),
-        )
-        self._save_user_input_to_config(user_input=user_input)
-        if user_input:
-            return await self.async_step_user(user_input=None)
-        return await self._test_login()
-
-    async def async_step_reauth(self, user_input=None):
-        """Handle reauth processing for the config flow."""
-        self._save_user_input_to_config(user_input)
-        self.config["reauth"] = True
-        reauth_schema = self._update_schema_defaults()
-        _LOGGER.debug(
-            "Creating reauth form with %s",
-            obfuscate(self.config),
-        )
-        self.automatic_steps = 0
-        if self.login is None:
-            try:
-                self.login = self.hass.data[DATA_ALEXAMEDIA]["accounts"][
-                    self.config[CONF_EMAIL]
-                ].get("login_obj")
-            except KeyError:
-                self.login = None
-        seconds_since_login: int = (
-            (datetime.datetime.now() - self.login.stats["login_timestamp"]).seconds
-            if self.login
-            else 60
-        )
-        if seconds_since_login < 60:
-            _LOGGER.debug(
-                "Relogin requested within %s seconds; manual login required",
-                seconds_since_login,
-            )
-            return self.async_show_form(
-                step_id="user",
-                data_schema=vol.Schema(reauth_schema),
-                description_placeholders={"message": "REAUTH"},
-            )
-        _LOGGER.debug("Attempting automatic relogin")
-        await sleep(15)
-        return await self.async_step_user_legacy(self.config)
-
-    async def _test_login(self):
-        login = self.login
-        email = login.email
-        _LOGGER.debug("Testing login status: %s", login.status)
-        if login.status and login.status.get("login_successful"):
-            existing_entry = await self.async_set_unique_id(f"{email} - {login.url}")
-            if self.config.get("reauth"):
-                self.config.pop("reauth")
-            if self.config.get(CONF_SECURITYCODE):
-                self.config.pop(CONF_SECURITYCODE)
-            if self.config.get("hass_url"):
-                self.config.pop("hass_url")
-            self.config[CONF_OAUTH] = {
-                "access_token": login.access_token,
-                "refresh_token": login.refresh_token,
-                "expires_in": login.expires_in,
-                "mac_dms": login.mac_dms,
-                "code_verifier": login.code_verifier,
-                "authorization_code": login.authorization_code,
-            }
-            self.hass.data.setdefault(
-                DATA_ALEXAMEDIA,
-                {"accounts": {}, "config_flows": {}, "notify_service": None},
-            )
-            self.hass.data[DATA_ALEXAMEDIA].setdefault("accounts", {})
-            self.hass.data[DATA_ALEXAMEDIA].setdefault("config_flows", {})
-            if existing_entry:
-                self.hass.config_entries.async_update_entry(
-                    existing_entry, data=self.config
-                )
-                _LOGGER.debug("Reauth successful for %s", hide_email(email))
-                self.hass.bus.async_fire(
-                    "alexa_media_relogin_success",
-                    event_data={"email": hide_email(email), "url": login.url},
-                )
-                host = urlparse(login.url).hostname or login.url
-                notification_id = f"alexa_media_{slugify(email)}_{slugify(host)}"
-                async_dismiss_persistent_notification(
-                    self.hass,
-                    notification_id,
-                )
-                if not self.hass.data[DATA_ALEXAMEDIA]["accounts"].get(
-                    self.config[CONF_EMAIL]
-                ):
-                    self.hass.data[DATA_ALEXAMEDIA]["accounts"][
-                        self.config[CONF_EMAIL]
-                    ] = {}
-                self.hass.data[DATA_ALEXAMEDIA]["accounts"][self.config[CONF_EMAIL]][
-                    "login_obj"
-                ] = self.login
-                self.hass.data[DATA_ALEXAMEDIA]["config_flows"][
-                    f"{email} - {login.url}"
-                ] = None
-                # Reload the integration to apply new credentials and clear error state
-                try:
-                    _LOGGER.debug("Reloading integration for %s", hide_email(email))
-                    await self.hass.config_entries.async_reload(existing_entry.entry_id)
-                except Exception:  # noqa: BLE001
-                    _LOGGER.warning(
-                        "Failed to reload integration for %s; restart may be needed",
-                        hide_email(email),
-                    )
-                return self.async_abort(reason="reauth_successful")
-            _LOGGER.debug(
-                "Setting up Alexa devices with %s", dict(obfuscate(self.config))
-            )
-            self._abort_if_unique_id_configured(self.config)
-            return self.async_create_entry(
-                title=f"{login.email} - {login.url}", data=self.config
-            )
-        if login.status and login.status.get("securitycode_required"):
-            _LOGGER.debug(
-                "Creating config_flow to request 2FA. Saved security code %s",
-                self.securitycode,
-            )
-            generated_securitycode: str = login.get_totp_token()
-            if (
-                self.securitycode or generated_securitycode
-            ) and self.automatic_steps < 2:
-                if self.securitycode:
-                    _LOGGER.debug(
-                        "Automatically submitting securitycode %s", self.securitycode
-                    )
-                else:
-                    _LOGGER.debug(
-                        "Automatically submitting generated securitycode %s",
-                        generated_securitycode,
-                    )
-                self.automatic_steps += 1
-                await sleep(5)
-                if generated_securitycode:
-                    return await self.async_step_user_legacy(
-                        user_input={CONF_SECURITYCODE: generated_securitycode}
-                    )
-                return await self.async_step_user_legacy(
-                    user_input={CONF_SECURITYCODE: self.securitycode}
-                )
-        if login.status and (login.status.get("login_failed")):
-            _LOGGER.debug("Login failed: %s", login.status.get("login_failed"))
-            host = urlparse(login.url).hostname or login.url
-            notification_id = f"alexa_media_{slugify(email)}_{slugify(host)}"
-            await login.close()
-            async_dismiss_persistent_notification(
-                self.hass,
-                notification_id,
-            )
-            return self.async_abort(reason="login_failed")
-        new_schema = self._update_schema_defaults()
-        if login.status and login.status.get("error_message"):
-            _LOGGER.debug("Login error detected: %s", login.status.get("error_message"))
-            if (
-                login.status.get("error_message")
-                in {
-                    "There was a problem\n            Enter a valid email or mobile number\n          "
-                }
-                and self.automatic_steps < 2
-            ):
-                _LOGGER.debug(
-                    "Trying automatic resubmission %s for error_message 'valid email'",
-                    self.automatic_steps,
-                )
-                self.automatic_steps += 1
-                await sleep(5)
-                return await self.async_step_user_legacy(user_input=self.config)
-            _LOGGER.debug(
-                "Done with automatic resubmission for error_message 'valid email'; returning error message",
-            )
-        self.automatic_steps = 0
-        return self.async_show_form(
-            step_id="user",
-            data_schema=vol.Schema(new_schema),
-            description_placeholders={
-                "message": f"  \n> {login.status.get('error_message', '')}"
-            },
-        )
 
     def _save_user_input_to_config(self, user_input=None) -> None:
-        # pylint: disable=too-many-branches
-        """Process user_input to save to self.config.
-
-        user_input can be a dictionary of strings or an internally
-        saved config_entry data entry. This function will convert all to internal strings.
-
-        """
+        """Fold submitted form values into self.config."""
         if user_input is None:
             return
-        if CONF_HASS_URL in user_input:
-            self.config[CONF_HASS_URL] = user_input[CONF_HASS_URL]
-        self.securitycode = user_input.get(CONF_SECURITYCODE)
-        if self.securitycode is not None:
-            self.config[CONF_SECURITYCODE] = self.securitycode
-        elif CONF_SECURITYCODE in self.config:
-            self.config.pop(CONF_SECURITYCODE)
-        if user_input.get(CONF_OTPSECRET) and user_input.get(CONF_OTPSECRET).replace(
-            " ", ""
+        for key in (
+            CONF_EMAIL,
+            CONF_URL,
+            CONF_INCLUDE_DEVICES,
+            CONF_EXCLUDE_DEVICES,
+            CONF_QUEUE_DELAY,
+            CONF_EXTENDED_ENTITY_DISCOVERY,
+            CONF_DEBUG,
         ):
-            self.config[CONF_OTPSECRET] = user_input[CONF_OTPSECRET].replace(" ", "")
-        elif user_input.get(CONF_OTPSECRET):
-            # a blank line
-            self.config.pop(CONF_OTPSECRET)
-        if CONF_EMAIL in user_input:
-            self.config[CONF_EMAIL] = user_input[CONF_EMAIL]
-        if CONF_PASSWORD in user_input:
-            self.config[CONF_PASSWORD] = user_input[CONF_PASSWORD]
-        if CONF_URL in user_input:
-            self.config[CONF_URL] = user_input[CONF_URL]
-        if CONF_PUBLIC_URL in user_input:
-            if not user_input[CONF_PUBLIC_URL].endswith("/"):
-                user_input[CONF_PUBLIC_URL] = user_input[CONF_PUBLIC_URL] + "/"
-            self.config[CONF_PUBLIC_URL] = user_input[CONF_PUBLIC_URL]
+            if key in user_input:
+                self.config[key] = user_input[key]
         if CONF_SCAN_INTERVAL in user_input:
+            value = user_input[CONF_SCAN_INTERVAL]
             self.config[CONF_SCAN_INTERVAL] = (
-                user_input[CONF_SCAN_INTERVAL]
-                if not isinstance(user_input[CONF_SCAN_INTERVAL], timedelta)
-                else user_input[CONF_SCAN_INTERVAL].total_seconds()
+                value.total_seconds() if hasattr(value, "total_seconds") else value
             )
-        if CONF_QUEUE_DELAY in user_input:
-            self.config[CONF_QUEUE_DELAY] = user_input[CONF_QUEUE_DELAY]
-        if CONF_INCLUDE_DEVICES in user_input:
-            if isinstance(user_input[CONF_INCLUDE_DEVICES], list):
-                self.config[CONF_INCLUDE_DEVICES] = (
-                    reduce(lambda x, y: f"{x},{y}", user_input[CONF_INCLUDE_DEVICES])
-                    if user_input[CONF_INCLUDE_DEVICES]
-                    else ""
-                )
-            else:
-                self.config[CONF_INCLUDE_DEVICES] = user_input[CONF_INCLUDE_DEVICES]
-        if CONF_EXCLUDE_DEVICES in user_input:
-            if isinstance(user_input[CONF_EXCLUDE_DEVICES], list):
-                self.config[CONF_EXCLUDE_DEVICES] = (
-                    reduce(lambda x, y: f"{x},{y}", user_input[CONF_EXCLUDE_DEVICES])
-                    if user_input[CONF_EXCLUDE_DEVICES]
-                    else ""
-                )
-            else:
-                self.config[CONF_EXCLUDE_DEVICES] = user_input[CONF_EXCLUDE_DEVICES]
-        if CONF_EXTENDED_ENTITY_DISCOVERY in user_input:
-            self.config[CONF_EXTENDED_ENTITY_DISCOVERY] = user_input[
-                CONF_EXTENDED_ENTITY_DISCOVERY
-            ]
-        if CONF_DEBUG in user_input:
-            self.config[CONF_DEBUG] = user_input[CONF_DEBUG]
-
-    def _update_schema_defaults(self) -> Any:
-        new_schema = self._update_ord_dict(
-            self.data_schema,
-            {
-                vol.Required(
-                    CONF_URL, default=self.config.get(CONF_URL, "amazon.com")
-                ): str,
-                vol.Required(CONF_EMAIL, default=self.config.get(CONF_EMAIL, "")): str,
-                vol.Required(
-                    CONF_PASSWORD, default=self.config.get(CONF_PASSWORD, "")
-                ): str,
-                vol.Required(
-                    CONF_SECURITYCODE,
-                    default=self.securitycode if self.securitycode else "",
-                ): str,
-                vol.Required(
-                    CONF_OTPSECRET, default=self.config.get(CONF_OTPSECRET, "")
-                ): str,
-                vol.Optional(
-                    CONF_PUBLIC_URL,
-                    default=self.config.get(CONF_PUBLIC_URL, DEFAULT_PUBLIC_URL),
-                ): str,
-                vol.Optional(
-                    CONF_INCLUDE_DEVICES,
-                    default=self.config.get(CONF_INCLUDE_DEVICES, ""),
-                ): str,
-                vol.Optional(
-                    CONF_EXCLUDE_DEVICES,
-                    default=self.config.get(CONF_EXCLUDE_DEVICES, ""),
-                ): str,
-                vol.Optional(
-                    CONF_SCAN_INTERVAL, default=self.config.get(CONF_SCAN_INTERVAL, 60)
-                ): int,
-                vol.Optional(
-                    CONF_QUEUE_DELAY, default=self.config.get(CONF_QUEUE_DELAY, 1.5)
-                ): float,
-                vol.Optional(
-                    CONF_EXTENDED_ENTITY_DISCOVERY,
-                    default=self.config.get(
-                        CONF_EXTENDED_ENTITY_DISCOVERY,
-                        DEFAULT_EXTENDED_ENTITY_DISCOVERY,
-                    ),
-                ): bool,
-                vol.Optional(
-                    CONF_DEBUG, default=self.config.get(CONF_DEBUG, False)
-                ): bool,
-            },
-        )
-        return new_schema
+        if CONF_PUBLIC_URL in user_input:
+            public_url = user_input[CONF_PUBLIC_URL]
+            if public_url and not public_url.endswith("/"):
+                public_url = public_url + "/"
+            self.config[CONF_PUBLIC_URL] = public_url
 
     @staticmethod
     @callback
@@ -918,7 +311,7 @@ class AlexaMediaFlowHandler(config_entries.ConfigFlow):
 
 
 class OptionsFlowHandler(config_entries.OptionsFlow):
-    """Handle a option flow for Alexa Media."""
+    """Handle an options flow for Alexa Media."""
 
     def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
         """Initialize options flow."""
@@ -929,8 +322,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
-        """Manage the options"""
-
+        """Manage the options."""
         self.options_schema = OrderedDict(
             [
                 (
@@ -993,35 +385,24 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         )
 
         if user_input is not None:
-            """Preserve these parameters"""
-            if CONF_URL in self.config_entry.data:
-                user_input[CONF_URL] = self.config_entry.data[CONF_URL]
-            if CONF_EMAIL in self.config_entry.data:
-                user_input[CONF_EMAIL] = self.config_entry.data[CONF_EMAIL]
-            if CONF_PASSWORD in self.config_entry.data:
-                user_input[CONF_PASSWORD] = self.config_entry.data[CONF_PASSWORD]
-            if CONF_SECURITYCODE in self.config_entry.data:
-                user_input[CONF_SECURITYCODE] = self.config_entry.data[
-                    CONF_SECURITYCODE
-                ]
-            if CONF_OTPSECRET in self.config_entry.data:
-                user_input[CONF_OTPSECRET] = self.config_entry.data[CONF_OTPSECRET]
-            if CONF_OAUTH in self.config_entry.data:
-                user_input[CONF_OAUTH] = self.config_entry.data[CONF_OAUTH]
-            """Ensure public_url ends with trailing slash"""
-            if CONF_PUBLIC_URL in self.config_entry.data:
-                if not user_input[CONF_PUBLIC_URL].endswith("/"):
-                    user_input[CONF_PUBLIC_URL] = user_input[CONF_PUBLIC_URL] + "/"
-            """Remove leading/trailing spaces in device strings"""
-            if CONF_INCLUDE_DEVICES in self.config_entry.data:
+            # Preserve identity/credential-linkage fields the options form omits.
+            for key in (CONF_URL, CONF_EMAIL, CONF_SECURE, CONF_OAUTH):
+                if key in self.config_entry.data:
+                    user_input[key] = self.config_entry.data[key]
+            if (
+                CONF_PUBLIC_URL in user_input
+                and user_input[CONF_PUBLIC_URL]
+                and not user_input[CONF_PUBLIC_URL].endswith("/")
+            ):
+                user_input[CONF_PUBLIC_URL] = user_input[CONF_PUBLIC_URL] + "/"
+            if CONF_INCLUDE_DEVICES in user_input:
                 user_input[CONF_INCLUDE_DEVICES] = user_input[
                     CONF_INCLUDE_DEVICES
                 ].strip()
-            if CONF_EXCLUDE_DEVICES in self.config_entry.data:
+            if CONF_EXCLUDE_DEVICES in user_input:
                 user_input[CONF_EXCLUDE_DEVICES] = user_input[
                     CONF_EXCLUDE_DEVICES
                 ].strip()
-
             self.hass.config_entries.async_update_entry(
                 self.config_entry, data=user_input, options=self.config_entry.options
             )
@@ -1032,149 +413,3 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
             data_schema=vol.Schema(self.options_schema),
             description_placeholders={"message": ""},
         )
-
-
-class AlexaMediaAuthorizationCallbackView(HomeAssistantView):
-    """Handle callback from external auth."""
-
-    url = AUTH_CALLBACK_PATH
-    name = AUTH_CALLBACK_NAME
-    requires_auth = False
-
-    async def get(self, request: web.Request):
-        """Receive authorization confirmation."""
-        hass = request.app["hass"]
-        try:
-            await hass.config_entries.flow.async_configure(
-                flow_id=request.query["flow_id"], user_input=None
-            )
-        except (KeyError, UnknownFlow) as ex:
-            _LOGGER.debug("Callback flow_id is invalid.")
-            raise HTTPBadRequest() from ex
-        return web_response.Response(
-            headers={"content-type": "text/html"},
-            text="<script>window.close()</script>Success! This window can be closed",
-        )
-
-
-class AlexaMediaAuthorizationProxyView(HomeAssistantView):
-    """Handle proxy connections."""
-
-    url: str = AUTH_PROXY_PATH
-    extra_urls: list[str] = [f"{AUTH_PROXY_PATH}/{{tail:.*}}"]
-    name: str = AUTH_PROXY_NAME
-    requires_auth: bool = False
-    handler: web.RequestHandler = None
-    known_ips: dict[str, datetime.datetime] = {}
-    auth_seconds: int = 300
-
-    def __init__(self, handler: web.RequestHandler):
-        """Initialize routes for view.
-
-        Args:
-            handler (web.RequestHandler): Handler to apply to all method types
-
-        """
-        AlexaMediaAuthorizationProxyView.handler = handler
-        for method in ("get", "post", "delete", "put", "patch", "head", "options"):
-            setattr(self, method, self.check_auth())
-
-    @classmethod
-    def check_auth(cls):
-        """Wrap authentication into the handler."""
-
-        async def wrapped(request, **kwargs):
-            """Notify that the API is running."""
-            hass = request.app["hass"]
-            success = False
-            if (
-                request.remote not in cls.known_ips
-                or (datetime.datetime.now() - cls.known_ips.get(request.remote)).seconds
-                > cls.auth_seconds
-            ):
-                try:
-                    flow_id = request.url.query["config_flow_id"]
-                except KeyError as ex:
-                    raise Unauthorized() from ex
-                for flow in hass.config_entries.flow.async_progress():
-                    if flow["flow_id"] == flow_id:
-                        _LOGGER.debug(
-                            "Found flow_id; adding %s to known_ips for %s seconds",
-                            request.remote,
-                            cls.auth_seconds,
-                        )
-                        success = True
-                if not success:
-                    raise Unauthorized()
-                cls.known_ips[request.remote] = datetime.datetime.now()
-            _sensitive_keys = {
-                "authorization",
-                "cookie",
-                "set-cookie",
-                "x-amz-security-token",
-            }
-            if _LOGGER.isEnabledFor(logging.DEBUG):
-                _safe_req_headers = {
-                    k: ("***" if k.lower() in _sensitive_keys else v)
-                    for k, v in request.headers.items()
-                }
-                _LOGGER.debug(
-                    "Proxy request: %s %s | Remote: %s | Headers: %s",
-                    request.method,
-                    request.url,
-                    request.remote,
-                    _safe_req_headers,
-                )
-            try:
-                result = await cls.handler(request, **kwargs)
-                if _LOGGER.isEnabledFor(logging.DEBUG):
-                    _safe_resp_headers = (
-                        {
-                            k: ("***" if k.lower() in _sensitive_keys else v)
-                            for k, v in result.headers.items()
-                        }
-                        if hasattr(result, "headers")
-                        else "unknown"
-                    )
-                    _LOGGER.debug(
-                        "Proxy response: %s %s | Status: %s | Response headers: %s",
-                        request.method,
-                        request.url,
-                        result.status if hasattr(result, "status") else "unknown",
-                        _safe_resp_headers,
-                    )
-                return result
-            except httpx.ConnectError as ex:
-                _LOGGER.warning("Detected Connection error: %s", ex)
-                return web_response.Response(
-                    headers={"content-type": "text/html"},
-                    text="Connection Error! Please try refreshing. "
-                    + "If this persists, please report this error to "
-                    + f"<a href={ISSUE_URL}>here</a>.",
-                )
-            except web.HTTPException:
-                raise  # Let aiohttp handle redirects (HTTPFound) and other HTTP exceptions
-            except Exception as ex:  # pylint: disable=broad-except
-                _LOGGER.warning(
-                    "Proxy exception at %s %s: %s - %s",
-                    request.method,
-                    request.url,
-                    type(ex).__name__,
-                    ex,
-                    exc_info=True,
-                )
-                return web_response.Response(
-                    headers={"content-type": "text/html"},
-                    text="An unexpected error occurred during login. "
-                    + "Please try refreshing. "
-                    + "If this persists, please report this error to "
-                    + f"<a href={ISSUE_URL}>here</a>:"
-                    + f"<br /><pre>{html_lib.escape(type(ex).__name__)}</pre>",
-                )
-
-        return wrapped
-
-    @classmethod
-    def reset(cls) -> None:
-        """Reset the view."""
-        cls.known_ips = {}

--- a/custom_components/alexa_media/config_flow.py
+++ b/custom_components/alexa_media/config_flow.py
@@ -17,7 +17,15 @@ import logging
 from typing import Any, Optional
 
 import aiohttp
-from alexapy import EnrollmentError, EnrollmentFlow, hide_email, obfuscate
+from alexapy import (
+    AuthTerminalError,
+    AuthTransientError,
+    EnrollmentError,
+    EnrollmentFlow,
+    TokenManager,
+    hide_email,
+    obfuscate,
+)
 from awesomeversion import AwesomeVersion
 from homeassistant import config_entries
 from homeassistant.const import (
@@ -103,7 +111,16 @@ class AlexaMediaFlowHandler(config_entries.ConfigFlow):
                 data_schema=vol.Schema(self._user_schema()),
                 description_placeholders={"message": "REAUTH" if reauth else ""},
             )
-        self._enrollment = EnrollmentFlow(domain=self.config[CONF_URL])
+        try:
+            self._enrollment = EnrollmentFlow(domain=self.config[CONF_URL])
+        except EnrollmentError as err:
+            _LOGGER.debug("Rejected domain %s: %s", self.config.get(CONF_URL), err)
+            return self.async_show_form(
+                step_id="user",
+                data_schema=vol.Schema(self._user_schema()),
+                errors={"base": "invalid_domain"},
+                description_placeholders={"message": "REAUTH" if reauth else ""},
+            )
         return self.async_show_form(
             step_id="paste",
             data_schema=vol.Schema({vol.Required(CONF_PASTE_URL): str}),
@@ -130,6 +147,23 @@ class AlexaMediaFlowHandler(config_entries.ConfigFlow):
         except EnrollmentError as err:
             _LOGGER.debug("Device registration failed: %s", err)
             return self._paste_form("register_failed")
+        # Account binding is mandatory: without a stable Amazon account id we
+        # cannot enforce the reauth mismatch / duplicate guards.
+        if not creds.customer_id:
+            _LOGGER.debug("Registration returned no account id; rejecting")
+            return self._paste_form("register_failed")
+        # Validate the freshly minted credentials before persisting anything, so
+        # a bad registration cannot overwrite a working store (reauth) or create
+        # a dead entry.
+        try:
+            async with aiohttp.ClientSession() as session:
+                await TokenManager(creds).async_refresh_access_token(session)
+        except AuthTerminalError as err:
+            _LOGGER.debug("New credentials rejected on validation: %s", err)
+            return self._paste_form("register_failed")
+        except AuthTransientError as err:
+            _LOGGER.debug("Transient error validating new credentials: %s", err)
+            return self._paste_form("try_again")
         return await self._finish_secure_enrollment(creds)
 
     async def _finish_secure_enrollment(self, creds) -> FlowResult:
@@ -142,12 +176,17 @@ class AlexaMediaFlowHandler(config_entries.ConfigFlow):
         url = self.config[CONF_URL]
         existing_entry = self._reauth_entry()
 
-        if creds.customer_id:
-            await self.async_set_unique_id(creds.customer_id)
-            if existing_entry:
+        await self.async_set_unique_id(creds.customer_id)
+        if existing_entry:
+            # A legacy (pre-secure) entry is keyed by "<email> - <region>", not
+            # the Amazon account id. Binding it to the account id for the first
+            # time is expected; only reject when an already-account-bound entry
+            # is being reauthenticated against a different account.
+            existing_uid = existing_entry.unique_id or ""
+            if existing_uid.startswith("amzn1.account"):
                 self._abort_if_unique_id_mismatch(reason="wrong_account")
-            else:
-                self._abort_if_unique_id_configured()
+        else:
+            self._abort_if_unique_id_configured()
 
         # The config entry never holds secrets; the minimized device credentials
         # go to the dedicated protected store.
@@ -169,7 +208,7 @@ class AlexaMediaFlowHandler(config_entries.ConfigFlow):
             store = SecureCredentialStore(self.hass, existing_entry.entry_id)
             await store.async_save(creds.as_dict(), pending_validation=False)
             self.hass.config_entries.async_update_entry(
-                existing_entry, data=self.config
+                existing_entry, data=self.config, unique_id=creds.customer_id
             )
             await self.hass.config_entries.async_reload(existing_entry.entry_id)
             _LOGGER.debug("Secure reauth successful for %s", hide_email(email))

--- a/custom_components/alexa_media/const.py
+++ b/custom_components/alexa_media/const.py
@@ -59,6 +59,8 @@ CONF_SCAN_INTERVAL = (
 )
 CONF_TOTP_REGISTER = "registered"
 CONF_OAUTH = "oauth"
+CONF_SECURE = "secure_enrollment"
+CONF_PASTE_URL = "paste_url"
 DATA_LISTENER = "listener"
 
 EXCEPTION_TEMPLATE = "An exception of type {0} occurred. Arguments:\n{1!r}"
@@ -174,6 +176,9 @@ DEVICE_PLAYER_BUCKETS = ("devices", "media_players", "players")
 TO_REDACT: set[str] = {
     "email",
     "password",
+    "serial",
+    "customer_id",
+    "paste_url",
     "access_token",
     "refresh_token",
     "token",

--- a/custom_components/alexa_media/manifest.json
+++ b/custom_components/alexa_media/manifest.json
@@ -9,7 +9,7 @@
   "issue_tracker": "https://github.com/alandtse/alexa_media_player/issues",
   "loggers": ["alexapy"],
   "requirements": [
-    "alexapy==1.29.25",
+    "alexapy==1.30.0",
     "packaging>=20.3",
     "wrapt>=1.14.0",
     "dictor>=0.1.12,<0.2"

--- a/custom_components/alexa_media/manifest.json
+++ b/custom_components/alexa_media/manifest.json
@@ -9,7 +9,7 @@
   "issue_tracker": "https://github.com/alandtse/alexa_media_player/issues",
   "loggers": ["alexapy"],
   "requirements": [
-    "alexapy>=1.30.0",
+    "alexapy>=1.30.0,<2.0.0",
     "packaging>=20.3",
     "wrapt>=1.14.0",
     "dictor>=0.1.12,<0.2"

--- a/custom_components/alexa_media/manifest.json
+++ b/custom_components/alexa_media/manifest.json
@@ -9,10 +9,10 @@
   "issue_tracker": "https://github.com/alandtse/alexa_media_player/issues",
   "loggers": ["alexapy"],
   "requirements": [
-    "alexapy>=1.30.0,<2.0.0",
+    "alexapy==1.29.25",
     "packaging>=20.3",
     "wrapt>=1.14.0",
     "dictor>=0.1.12,<0.2"
   ],
-  "version": "6.0.0"
+  "version": "5.15.6"
 }

--- a/custom_components/alexa_media/manifest.json
+++ b/custom_components/alexa_media/manifest.json
@@ -7,12 +7,12 @@
   "documentation": "https://github.com/alandtse/alexa_media_player/wiki",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/alandtse/alexa_media_player/issues",
-  "loggers": ["alexapy", "authcaptureproxy"],
+  "loggers": ["alexapy"],
   "requirements": [
-    "alexapy==1.29.25",
+    "alexapy>=1.30.0",
     "packaging>=20.3",
     "wrapt>=1.14.0",
     "dictor>=0.1.12,<0.2"
   ],
-  "version": "5.15.6"
+  "version": "6.0.0"
 }

--- a/custom_components/alexa_media/secure_store.py
+++ b/custom_components/alexa_media/secure_store.py
@@ -1,0 +1,92 @@
+"""Protected at-rest storage for minimized device credentials.
+
+SPDX-License-Identifier: Apache-2.0
+
+The auth redesign (RFC #3523) persists only the durable device credentials the
+runtime derives everything else from: the device ``refresh_token``, ``mac_dms``,
+the device ``serial``, and the bound Amazon account identifier. They live in a
+dedicated ``Store(private=True, atomic_writes=True)`` file rather than the shared
+config entry so they are excluded from casual config sharing and diagnostics.
+
+This is file-permission hygiene, not host-compromise protection: ``.storage`` is
+included in Home Assistant backups, and anyone who can read the filesystem can
+read these credentials. See the design doc for the honest threat model:
+https://github.com/superbeetle1973/alexa-auth-redesign
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.storage import Store
+
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+STORAGE_VERSION = 1
+_STORAGE_KEY_TMPL = f"{DOMAIN}.secure_credentials.{{entry_id}}"
+
+# Keys of the minimized credential set persisted to the protected store.
+CREDENTIAL_KEYS = ("refresh_token", "mac_dms", "serial", "customer_id", "domain")
+
+
+class SecureCredentialStore:
+    """Per-config-entry wrapper around a private HA Store.
+
+    Holds the minimized ``DeviceCredentials`` for one Amazon account. The
+    ``pending_validation`` flag lets migration write credentials before they
+    have been proven against Amazon and clear it on the first successful
+    refresh, per the lazy validate-then-delete migration design.
+    """
+
+    def __init__(self, hass: HomeAssistant, entry_id: str) -> None:
+        self._store: Store = Store(
+            hass,
+            STORAGE_VERSION,
+            _STORAGE_KEY_TMPL.format(entry_id=entry_id),
+            private=True,
+            atomic_writes=True,
+        )
+        self._data: dict[str, Any] | None = None
+
+    async def async_load(self) -> dict[str, Any] | None:
+        """Load the stored credential payload, or None if nothing is stored."""
+        if self._data is None:
+            self._data = await self._store.async_load()
+        return self._data
+
+    async def async_save(
+        self, credentials: dict[str, Any], *, pending_validation: bool = False
+    ) -> None:
+        """Persist the minimized credential set atomically.
+
+        Only the recognized credential keys are written; anything else in the
+        supplied mapping (a stray password, cookies) is dropped rather than
+        persisted.
+        """
+        payload = {key: credentials.get(key) for key in CREDENTIAL_KEYS}
+        payload["pending_validation"] = pending_validation
+        await self._store.async_save(payload)
+        self._data = payload
+
+    async def async_mark_validated(self) -> None:
+        """Clear the pending-validation flag after a successful Amazon round-trip."""
+        data = await self.async_load()
+        if not data or not data.get("pending_validation"):
+            return
+        data = dict(data, pending_validation=False)
+        await self._store.async_save(data)
+        self._data = data
+
+    async def async_remove(self) -> None:
+        """Delete the protected store file (best-effort on teardown)."""
+        await self._store.async_remove()
+        self._data = None
+
+    @property
+    def key(self) -> str:
+        """Storage key, exposed for diagnostics/tests."""
+        return self._store.key

--- a/custom_components/alexa_media/strings.json
+++ b/custom_components/alexa_media/strings.json
@@ -1,20 +1,15 @@
 {
   "config": {
     "abort": {
-      "forgot_password": "The Forgot Password page was detected. This normally is the result of too many failed logins. Amazon may require action before a relogin can be attempted.",
       "login_failed": "Alexa Media Player failed to login.",
-      "reauth_successful": "Alexa Media Player successfully reauthenticated. Please ignore the \"Aborted\" message from HA."
+      "reauth_successful": "Alexa Media Player successfully reauthenticated. Please ignore the \"Aborted\" message from HA.",
+      "wrong_account": "The Amazon account you logged in with does not match this entry. Log in with the same account you originally enrolled.",
+      "already_configured": "This Amazon account is already configured."
     },
     "error": {
-      "connection_error": "Error connecting; check network and retry",
-      "identifier_exists": "Email for Alexa URL already registered",
-      "invalid_credentials": "Invalid credentials",
-      "invalid_auth": "Login was not successful. Please double-check your email, password, and Authenticator key.",
-      "oauth_error": "Could not complete OAuth login. Please try again.",
-      "invalid_url": "URL is invalid: {message}",
-      "2fa_key_invalid": "{otp_secret} is invalid",
-      "unable_to_connect_hass_url": "Unable to connect to Home Assistant Local URL. Please check the URL under Settings > System > Network > Home Assistant URL > Local network",
-      "unknown_error": "Unknown error: {message}"
+      "paste_required": "Paste the full redirect URL from your browser.",
+      "paste_invalid": "That URL is not a valid Amazon maplanding redirect for this region.",
+      "register_failed": "Device registration failed (the code may have expired). Restart the login and paste the URL within ~5 minutes."
     },
     "step": {
       "user": {
@@ -23,35 +18,24 @@
           "email": "Email Address",
           "exclude_devices": "or Exclude these devices from all (comma separated)",
           "extended_entity_discovery": "Include additional sensors, switches and lights",
-          "hass_url": "Local network URL to access Home Assistant",
           "include_devices": "Only include these devices (comma separated)",
-          "otp_secret": "52-character Authenticator App Key for Amazon 2SV",
-          "password": "Password",
-          "public_url": "Public URL shared with external hosted services",
           "queue_delay": "Delay to queue multiple commands together (seconds)",
           "scan_interval": "Scheduled polling interval (seconds)",
-          "securitycode": "One-time password (OTP)",
-          "should_get_network": "Discover Alexa network",
           "url": "Amazon region domain (e.g., amazon.co.uk)"
         },
         "data_description": {
           "debug": "Enables very verbose, trace-level logging for advanced troubleshooting.\nNot recommended for normal operation due to increased log volume.\nEnsure logger levels are set to DEBUG for full output.",
-          "otp_secret": "Example: 35T5 LQSY I5IO 3EFQ LGAJ I6YB JWBY JJPR PYT7 XPPW IDAK SQBJ CVXA"
-        }
-      },
-      "proxy_warning": {
-        "data": {
-          "proxy_warning": "Ignore and Continue - I understand that no support for login issues are provided for bypassing this warning."
+          "email": "Only used as a label and to confirm the region — your password is never entered here."
         },
-        "description": "The HA server cannot connect to the URL provided: {hass_url}.\n> {error}\n\nTo fix this, please confirm your browser can reach {hass_url}. This field is from Settings > System > Network > Home Assistant URL.\n\nIf you are **certain** your browser can reach this URL, you can bypass this warning.",
-        "title": "Alexa Media Player - Unable to Connect to HA URL"
+        "description": "Enter your Amazon account email and region. You will log in on Amazon's own page in the next step; no password or Authenticator key is entered in Home Assistant.",
+        "title": "Alexa Media Player - Account"
       },
-      "totp_register": {
+      "paste": {
         "data": {
-          "registered": "Yes, OTP code was verified"
+          "paste_url": "Pasted redirect URL"
         },
-        "description": "**{email} - alexa.{url}**  \nHave you verified the OTP code in Amazon 2SV?  \n >OTP Code: {message}",
-        "title": "Alexa Media Player - OTP Confirmation"
+        "description": "1. Open this URL in your browser and log in to Amazon:\n\n{url}\n\n2. After login you land on a blank/error page at /ap/maplanding — that is expected.\n3. Copy the FULL address-bar URL and paste it below (it expires in ~5 minutes).",
+        "title": "Alexa Media Player - Complete Login ({email})"
       }
     }
   },

--- a/custom_components/alexa_media/strings.json
+++ b/custom_components/alexa_media/strings.json
@@ -7,9 +7,11 @@
       "already_configured": "This Amazon account is already configured."
     },
     "error": {
+      "invalid_domain": "Unsupported Amazon region domain. Use a domain like amazon.com, amazon.co.uk, or amazon.de.",
       "paste_required": "Paste the full redirect URL from your browser.",
       "paste_invalid": "That URL is not a valid Amazon maplanding redirect for this region.",
-      "register_failed": "Device registration failed (the code may have expired). Restart the login and paste the URL within ~5 minutes."
+      "register_failed": "Device registration failed (the code may have expired). Restart the login and paste the URL within ~5 minutes.",
+      "try_again": "Could not reach Amazon to verify the new login. Check your connection and try again."
     },
     "step": {
       "user": {

--- a/custom_components/alexa_media/translations/en.json
+++ b/custom_components/alexa_media/translations/en.json
@@ -1,57 +1,41 @@
 {
   "config": {
     "abort": {
-      "forgot_password": "The Forgot Password page was detected. This normally is the result of too many failed logins. Amazon may require action before a relogin can be attempted.",
       "login_failed": "Alexa Media Player failed to login.",
-      "reauth_successful": "Alexa Media Player successfully reauthenticated. Please ignore the \"Aborted\" message from HA."
+      "reauth_successful": "Alexa Media Player successfully reauthenticated. Please ignore the \"Aborted\" message from HA.",
+      "wrong_account": "The Amazon account you logged in with does not match this entry. Log in with the same account you originally enrolled.",
+      "already_configured": "This Amazon account is already configured."
     },
     "error": {
-      "2fa_key_invalid": "{otp_secret} is invalid",
-      "connection_error": "Error connecting; check network and retry",
-      "identifier_exists": "Email for Alexa URL already registered",
-      "invalid_auth": "Login was not successful. Please double-check your email, password, and Authenticator key.",
-      "invalid_credentials": "Invalid credentials",
-      "invalid_url": "URL is invalid: {message}",
-      "oauth_error": "Could not complete OAuth login. Please try again.",
-      "unable_to_connect_hass_url": "Unable to connect to Home Assistant Local URL. Please check the URL under Settings > System > Network > Home Assistant URL > Local network",
-      "unknown_error": "Unknown error: {message}"
+      "paste_required": "Paste the full redirect URL from your browser.",
+      "paste_invalid": "That URL is not a valid Amazon maplanding redirect for this region.",
+      "register_failed": "Device registration failed (the code may have expired). Restart the login and paste the URL within ~5 minutes."
     },
     "step": {
-      "proxy_warning": {
-        "data": {
-          "proxy_warning": "Ignore and Continue - I understand that no support for login issues are provided for bypassing this warning."
-        },
-        "description": "The HA server cannot connect to the URL provided: {hass_url}.\n> {error}\n\nTo fix this, please confirm your browser can reach {hass_url}. This field is from Settings > System > Network > Home Assistant URL.\n\nIf you are **certain** your browser can reach this URL, you can bypass this warning.",
-        "title": "Alexa Media Player - Unable to Connect to HA URL"
-      },
-      "totp_register": {
-        "data": {
-          "registered": "Yes, OTP code was verified"
-        },
-        "description": "**{email} - alexa.{url}**  \nHave you verified the OTP code in Amazon 2SV?  \n >OTP Code: {message}",
-        "title": "Alexa Media Player - OTP Confirmation"
-      },
       "user": {
         "data": {
           "debug": "Advanced debug",
           "email": "Email Address",
           "exclude_devices": "or Exclude these devices from all (comma separated)",
           "extended_entity_discovery": "Include additional sensors, switches and lights",
-          "hass_url": "Local network URL to access Home Assistant",
           "include_devices": "Only include these devices (comma separated)",
-          "otp_secret": "52-character Authenticator App Key for Amazon 2SV",
-          "password": "Password",
-          "public_url": "Public URL shared with external hosted services",
           "queue_delay": "Delay to queue multiple commands together (seconds)",
           "scan_interval": "Scheduled polling interval (seconds)",
-          "securitycode": "One-time password (OTP)",
-          "should_get_network": "Discover Alexa network",
           "url": "Amazon region domain (e.g., amazon.co.uk)"
         },
         "data_description": {
           "debug": "Enables very verbose, trace-level logging for advanced troubleshooting.\nNot recommended for normal operation due to increased log volume.\nEnsure logger levels are set to DEBUG for full output.",
-          "otp_secret": "Example: 35T5 LQSY I5IO 3EFQ LGAJ I6YB JWBY JJPR PYT7 XPPW IDAK SQBJ CVXA"
-        }
+          "email": "Only used as a label and to confirm the region — your password is never entered here."
+        },
+        "description": "Enter your Amazon account email and region. You will log in on Amazon's own page in the next step; no password or Authenticator key is entered in Home Assistant.",
+        "title": "Alexa Media Player - Account"
+      },
+      "paste": {
+        "data": {
+          "paste_url": "Pasted redirect URL"
+        },
+        "description": "1. Open this URL in your browser and log in to Amazon:\n\n{url}\n\n2. After login you land on a blank/error page at /ap/maplanding — that is expected.\n3. Copy the FULL address-bar URL and paste it below (it expires in ~5 minutes).",
+        "title": "Alexa Media Player - Complete Login ({email})"
       }
     }
   },

--- a/custom_components/alexa_media/translations/en.json
+++ b/custom_components/alexa_media/translations/en.json
@@ -7,9 +7,11 @@
       "already_configured": "This Amazon account is already configured."
     },
     "error": {
+      "invalid_domain": "Unsupported Amazon region domain. Use a domain like amazon.com, amazon.co.uk, or amazon.de.",
       "paste_required": "Paste the full redirect URL from your browser.",
       "paste_invalid": "That URL is not a valid Amazon maplanding redirect for this region.",
-      "register_failed": "Device registration failed (the code may have expired). Restart the login and paste the URL within ~5 minutes."
+      "register_failed": "Device registration failed (the code may have expired). Restart the login and paste the URL within ~5 minutes.",
+      "try_again": "Could not reach Amazon to verify the new login. Check your connection and try again."
     },
     "step": {
       "user": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ packages = [
 
 [tool.poetry.dependencies]
 python = ">=3.13,<4.0"
-alexapy = "1.29.25"
+alexapy = "1.30.0"
 aiohttp = ">=3.8.1"
 packaging = ">=20.3"
 wrapt = ">=1.14.0"

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -9,11 +9,7 @@ from custom_components.alexa_media.config_flow import (
     CONFIG_VERSION,
     AlexaMediaFlowHandler,
 )
-from custom_components.alexa_media.const import (
-    CONF_OAUTH,
-    CONF_PASTE_URL,
-    CONF_SECURE,
-)
+from custom_components.alexa_media.const import CONF_OAUTH, CONF_PASTE_URL, CONF_SECURE
 
 MAP_URL = (
     "https://www.amazon.com/ap/maplanding?"

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,354 +1,206 @@
-"""Tests for config_flow module."""
+"""Tests for the secure paste-URL config flow."""
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from alexapy import EnrollmentError
 import pytest
 
-from custom_components.alexa_media.config_flow import AlexaMediaFlowHandler
-from custom_components.alexa_media.const import DATA_ALEXAMEDIA
+from custom_components.alexa_media.config_flow import (
+    CONFIG_VERSION,
+    AlexaMediaFlowHandler,
+)
+from custom_components.alexa_media.const import (
+    CONF_OAUTH,
+    CONF_PASTE_URL,
+    CONF_SECURE,
+)
+
+MAP_URL = (
+    "https://www.amazon.com/ap/maplanding?"
+    "openid.oa2.authorization_code=ANsecretcode&openid.assoc_handle=amzn"
+)
 
 
-class TestReauthReload:
-    """Test that reauth triggers integration reload.
+def _creds(customer_id="amzn1.account.ABC"):
+    creds = MagicMock()
+    creds.refresh_token = "Atna|refresh"  # nosec B105
+    creds.mac_dms = {"device_private_key": "k", "adp_token": "t"}
+    creds.serial = "DEADBEEF"
+    creds.customer_id = customer_id
+    creds.domain = "amazon.com"
+    creds.as_dict.return_value = {
+        "refresh_token": "Atna|refresh",
+        "mac_dms": {"device_private_key": "k", "adp_token": "t"},
+        "serial": "DEADBEEF",
+        "customer_id": customer_id,
+        "domain": "amazon.com",
+    }
+    return creds
 
-    These tests verify the fix for the bug where the integration remained
-    in an error state after successful reauthentication because async_reload
-    was not called.
-    """
+
+class TestUserStep:
+    """Step 1: collect account/region and present the login URL."""
 
     @pytest.mark.asyncio
-    async def test_reauth_triggers_reload(self):
-        """Test that successful reauth calls async_reload to clear error state.
-
-        This test verifies the fix for the bug where the integration remained
-        in an error state after successful reauthentication because async_reload
-        was not called.
-
-        Test plan:
-        1. Trigger a reauth flow by simulating an existing entry
-        2. Complete the reauth successfully
-        3. Verify that async_reload is called to clear the error state
-        """
-        # Create flow handler
+    async def test_shows_form_without_input(self):
         flow = AlexaMediaFlowHandler()
         flow.hass = MagicMock()
-        flow.config = {
-            "email": "test@example.com",
-        }
+        result = await flow.async_step_user()
+        assert result["type"] == "form"
+        assert result["step_id"] == "user"
 
-        # Mock login object with successful status
-        mock_login = MagicMock()
-        mock_login.email = "test@example.com"
-        mock_login.url = "https://amazon.com"
-        mock_login.status = {"login_successful": True}
-        mock_login.access_token = "test_token"  # nosec B105
-        mock_login.refresh_token = "test_refresh"  # nosec B105
-        mock_login.expires_in = 3600
-        mock_login.mac_dms = "test_mac"
-        mock_login.code_verifier = "test_verifier"
-        mock_login.authorization_code = "test_code"
-        flow.login = mock_login
-
-        # Mock existing entry (simulates reauth scenario)
-        mock_entry = MagicMock()
-        mock_entry.entry_id = "test_entry_id"
-
-        # Setup hass.data structure
-        flow.hass.data = {
-            DATA_ALEXAMEDIA: {
-                "accounts": {},
-                "config_flows": {},
-            }
-        }
-
-        # Mock async_set_unique_id to return existing entry (triggers reauth path)
-        flow.async_set_unique_id = AsyncMock(return_value=mock_entry)
-
-        # Mock config entries methods
-        flow.hass.config_entries.async_update_entry = MagicMock()
-        flow.hass.config_entries.async_reload = AsyncMock()
-
-        # Mock other required methods
-        flow.hass.bus.async_fire = MagicMock()
-        flow.async_abort = MagicMock(return_value={"type": "abort"})
-
-        # Patch async_dismiss_persistent_notification
+    @pytest.mark.asyncio
+    async def test_advances_to_paste_with_login_url(self):
+        flow = AlexaMediaFlowHandler()
+        flow.hass = MagicMock()
         with patch(
-            "custom_components.alexa_media.config_flow.async_dismiss_persistent_notification"
-        ):
-            # Call _test_login which handles reauth
-            await flow._test_login()
+            "custom_components.alexa_media.config_flow.EnrollmentFlow"
+        ) as enroll_cls:
+            enroll_cls.return_value.oauth_url = "https://www.amazon.com/ap/register?x=1"
+            result = await flow.async_step_user(
+                {"email": "user@example.com", "url": "amazon.com"}
+            )
+        assert result["type"] == "form"
+        assert result["step_id"] == "paste"
+        assert "amazon.com/ap/register" in result["description_placeholders"]["url"]
 
-        # Verify async_reload was called with the entry_id
-        flow.hass.config_entries.async_reload.assert_called_once_with("test_entry_id")
 
-        # Verify async_abort was called with reauth_successful
-        flow.async_abort.assert_called_once_with(reason="reauth_successful")
+class TestPasteStep:
+    """Step 2: parse the pasted redirect URL and register the device."""
 
-    @pytest.mark.asyncio
-    async def test_new_entry_does_not_trigger_reload(self):
-        """Test that new entry creation does not call async_reload.
-
-        Only reauth (existing entry update) should trigger reload.
-        New entries should use async_create_entry instead.
-        """
+    def _flow_at_paste(self):
         flow = AlexaMediaFlowHandler()
         flow.hass = MagicMock()
-        flow.config = {
-            "email": "test@example.com",
-        }
+        flow.config.update({"email": "user@example.com", "url": "amazon.com"})
+        flow._enrollment = MagicMock()
+        flow._enrollment.oauth_url = "https://www.amazon.com/ap/register"
+        return flow
 
-        # Mock login object
-        mock_login = MagicMock()
-        mock_login.email = "test@example.com"
-        mock_login.url = "https://amazon.com"
-        mock_login.status = {"login_successful": True}
-        mock_login.access_token = "test_token"  # nosec B105
-        mock_login.refresh_token = "test_refresh"  # nosec B105
-        mock_login.expires_in = 3600
-        mock_login.mac_dms = "test_mac"
-        mock_login.code_verifier = "test_verifier"
-        mock_login.authorization_code = "test_code"
-        flow.login = mock_login
+    @pytest.mark.asyncio
+    async def test_missing_paste_shows_error(self):
+        flow = self._flow_at_paste()
+        result = await flow.async_step_paste({})
+        assert result["type"] == "form"
+        assert result["errors"] == {"base": "paste_required"}
 
-        flow.hass.data = {
-            DATA_ALEXAMEDIA: {
-                "accounts": {},
-                "config_flows": {},
-            }
-        }
+    @pytest.mark.asyncio
+    async def test_invalid_url_shows_error(self):
+        flow = self._flow_at_paste()
+        flow._enrollment.parse_redirect_url.side_effect = EnrollmentError("bad host")
+        result = await flow.async_step_paste({CONF_PASTE_URL: "https://evil/x"})
+        assert result["errors"] == {"base": "paste_invalid"}
 
-        # Mock async_set_unique_id to return None (no existing entry = new setup)
-        flow.async_set_unique_id = AsyncMock(return_value=None)
+    @pytest.mark.asyncio
+    async def test_register_failure_shows_error(self):
+        flow = self._flow_at_paste()
+        flow._enrollment.parse_redirect_url.return_value = "ANcode"
+        flow._enrollment.async_register = AsyncMock(
+            side_effect=EnrollmentError("expired code")
+        )
+        result = await flow.async_step_paste({CONF_PASTE_URL: MAP_URL})
+        assert result["errors"] == {"base": "register_failed"}
 
-        # Mock methods
-        flow.hass.config_entries.async_reload = AsyncMock()
+    @pytest.mark.asyncio
+    async def test_success_creates_entry_and_stores_creds(self):
+        flow = self._flow_at_paste()
+        flow._enrollment.parse_redirect_url.return_value = "ANcode"
+        flow._enrollment.async_register = AsyncMock(return_value=_creds())
+        flow.async_set_unique_id = AsyncMock()
         flow._abort_if_unique_id_configured = MagicMock()
-        flow.async_create_entry = MagicMock(return_value={"type": "create_entry"})
-
-        await flow._test_login()
-
-        # Verify async_reload was NOT called for new entries
-        flow.hass.config_entries.async_reload.assert_not_called()
-
-        # Verify async_create_entry was called instead
-        flow.async_create_entry.assert_called_once()
-
-    @pytest.mark.asyncio
-    async def test_reauth_updates_credentials_before_reload(self):
-        """Test that credentials are updated before reload is triggered.
-
-        The async_update_entry should be called before async_reload
-        to ensure new credentials are in place.
-        """
-        flow = AlexaMediaFlowHandler()
-        flow.hass = MagicMock()
-        flow.config = {
-            "email": "test@example.com",
-        }
-
-        mock_login = MagicMock()
-        mock_login.email = "test@example.com"
-        mock_login.url = "https://amazon.com"
-        mock_login.status = {"login_successful": True}
-        mock_login.access_token = "new_access_token"  # nosec B105
-        mock_login.refresh_token = "new_refresh_token"  # nosec B105
-        mock_login.expires_in = 3600
-        mock_login.mac_dms = "test_mac"
-        mock_login.code_verifier = "test_verifier"
-        mock_login.authorization_code = "test_code"
-        flow.login = mock_login
-
-        mock_entry = MagicMock()
-        mock_entry.entry_id = "test_entry_id"
-
-        flow.hass.data = {
-            DATA_ALEXAMEDIA: {
-                "accounts": {},
-                "config_flows": {},
-            }
-        }
-
-        flow.async_set_unique_id = AsyncMock(return_value=mock_entry)
-
-        # Track call order
-        call_order: list[str] = []
-        flow.hass.config_entries.async_update_entry = MagicMock(
-            side_effect=lambda *_args, **_kwargs: call_order.append("update")
+        created = MagicMock()
+        created.entry_id = "entry123"
+        flow.async_create_entry = MagicMock(
+            return_value={"type": "create_entry", "result": created}
         )
-        flow.hass.config_entries.async_reload = AsyncMock(
-            side_effect=lambda *_args, **_kwargs: call_order.append("reload")
-        )
-        flow.hass.bus.async_fire = MagicMock()
-        flow.async_abort = MagicMock(return_value={"type": "abort"})
-
+        store = AsyncMock()
         with patch(
-            "custom_components.alexa_media.config_flow.async_dismiss_persistent_notification"
+            "custom_components.alexa_media.config_flow.SecureCredentialStore",
+            return_value=store,
         ):
-            await flow._test_login()
+            result = await flow.async_step_paste({CONF_PASTE_URL: MAP_URL})
 
-        # Verify update was called before reload
-        assert call_order == [
-            "update",
-            "reload",
-        ], f"Expected update before reload, got: {call_order}"
+        assert result["type"] == "create_entry"
+        # Entry is bound to the Amazon account id.
+        flow.async_set_unique_id.assert_awaited_once_with("amzn1.account.ABC")
+        # Credentials go to the protected store, never the entry data.
+        store.async_save.assert_awaited_once()
+        data = flow.async_create_entry.call_args.kwargs["data"]
+        assert data[CONF_SECURE] is True
+        assert "password" not in data
+        assert CONF_OAUTH not in data
+
+
+class TestReauth:
+    """Reauth must re-enroll and must not rebind to a different account."""
 
     @pytest.mark.asyncio
-    async def test_reauth_succeeds_even_when_reload_fails(self):
-        """Test that reauth completes successfully even if reload raises an exception.
-
-        The implementation includes defensive error handling that logs a warning
-        but still returns reauth_successful when async_reload fails. This ensures
-        credentials are updated even if the integration can't be reloaded.
-        """
+    async def test_reauth_routes_to_user_step(self):
         flow = AlexaMediaFlowHandler()
         flow.hass = MagicMock()
-        flow.config = {
-            "email": "test@example.com",
-        }
+        result = await flow.async_step_reauth({"email": "user@example.com"})
+        assert result["type"] == "form"
+        assert result["step_id"] == "user"
+        assert flow.config["reauth"] is True
 
-        mock_login = MagicMock()
-        mock_login.email = "test@example.com"
-        mock_login.url = "https://amazon.com"
-        mock_login.status = {"login_successful": True}
-        mock_login.access_token = "test_token"  # noqa: S105  # nosec B105
-        mock_login.refresh_token = "test_refresh"  # noqa: S105  # nosec B105
-        mock_login.expires_in = 3600
-        mock_login.mac_dms = "test_mac"
-        mock_login.code_verifier = "test_verifier"
-        mock_login.authorization_code = "test_code"
-        flow.login = mock_login
-
-        mock_entry = MagicMock()
-        mock_entry.entry_id = "test_entry_id"
-
-        flow.hass.data = {
-            DATA_ALEXAMEDIA: {
-                "accounts": {},
-                "config_flows": {},
-            }
-        }
-
-        flow.async_set_unique_id = AsyncMock(return_value=mock_entry)
+    @pytest.mark.asyncio
+    async def test_reauth_success_updates_and_reloads(self):
+        flow = AlexaMediaFlowHandler()
+        flow.hass = MagicMock()
+        flow.config.update(
+            {"email": "user@example.com", "url": "amazon.com", "reauth": True}
+        )
+        flow._enrollment = MagicMock()
+        flow._enrollment.parse_redirect_url.return_value = "ANcode"
+        flow._enrollment.async_register = AsyncMock(return_value=_creds())
+        existing = MagicMock()
+        existing.entry_id = "entry123"
+        flow._reauth_entry = MagicMock(return_value=existing)
+        flow.async_set_unique_id = AsyncMock()
+        flow._abort_if_unique_id_mismatch = MagicMock()
+        flow.async_abort = MagicMock(return_value={"type": "abort"})
         flow.hass.config_entries.async_update_entry = MagicMock()
-        # Simulate reload failure
-        flow.hass.config_entries.async_reload = AsyncMock(
-            side_effect=Exception("Reload failed")
-        )
-        flow.hass.bus.async_fire = MagicMock()
-        flow.async_abort = MagicMock(return_value={"type": "abort"})
-
+        flow.hass.config_entries.async_reload = AsyncMock()
+        store = AsyncMock()
         with patch(
-            "custom_components.alexa_media.config_flow.async_dismiss_persistent_notification"
+            "custom_components.alexa_media.config_flow.SecureCredentialStore",
+            return_value=store,
         ):
-            await flow._test_login()
+            result = await flow.async_step_paste({CONF_PASTE_URL: MAP_URL})
 
-        # Despite reload failure, reauth should still complete successfully
+        flow._abort_if_unique_id_mismatch.assert_called_once()
+        flow.hass.config_entries.async_reload.assert_awaited_once_with("entry123")
         flow.async_abort.assert_called_once_with(reason="reauth_successful")
-        # Credentials should have been updated
-        flow.hass.config_entries.async_update_entry.assert_called_once()
+        assert result["type"] == "abort"
 
-
-class TestConfigFlowInvalidOtpKeyDataSchema:
-    """Tests for handling invalid OTP key errors in config flow.
-
-    These tests verify that when a user provides an invalid 2FA/OTP key,
-    the configuration flow properly displays an error form WITH the data
-    schema so the user can correct their input.
-
-    The bug: async_show_form was called without data_schema parameter when
-    AlexapyPyotpInvalidKey was raised, causing the error form to display
-    without any input fields. Users could see the error but had no way to
-    correct their invalid OTP key.
-
-    The fix: Add data_schema=vol.Schema(self.proxy_schema) to the
-    async_show_form call in the exception handler.
-
-    Related issues: #3254, #3243, #3189
-    """
-
-    def test_bugfix_adds_data_schema_to_exception_handler(self):
-        """Test that the bugfix adds data_schema to the AlexapyPyotpInvalidKey handler.
-
-        This test reads the actual config_flow.py source code and verifies
-        that the exception handler includes data_schema in the async_show_form call.
-        """
-        with open(
-            "custom_components/alexa_media/config_flow.py", encoding="utf-8"
-        ) as f:
-            content = f.read()
-
-        # Check that the exception handler exists
-        assert (
-            "except AlexapyPyotpInvalidKey:" in content
-        ), "AlexapyPyotpInvalidKey exception handler not found in config_flow.py"
-
-        # Find the exception handler block
-        handler_start = content.find("except AlexapyPyotpInvalidKey:")
-        assert handler_start != -1
-
-        # Get the next ~500 characters to capture the full handler
-        handler_block = content[handler_start : handler_start + 500]
-
-        # Verify the handler returns async_show_form
-        assert (
-            "async_show_form" in handler_block
-        ), "async_show_form not found in AlexapyPyotpInvalidKey handler"
-
-        # CRITICAL: Verify data_schema is present in the handler
-        assert "data_schema" in handler_block, (
-            "BUGFIX MISSING: data_schema parameter not found in "
-            "AlexapyPyotpInvalidKey exception handler. "
-            "Without data_schema, users cannot correct their invalid OTP key. "
-            "See issues #3254, #3243, #3189."
+    @pytest.mark.asyncio
+    async def test_reauth_wrong_account_aborts(self):
+        flow = AlexaMediaFlowHandler()
+        flow.hass = MagicMock()
+        flow.config.update(
+            {"email": "user@example.com", "url": "amazon.com", "reauth": True}
         )
-
-        # Verify it uses proxy_schema
-        assert "proxy_schema" in handler_block, (
-            "proxy_schema not found in AlexapyPyotpInvalidKey handler. "
-            "The handler should use vol.Schema(self.proxy_schema) for data_schema."
+        flow._enrollment = MagicMock()
+        flow._enrollment.parse_redirect_url.return_value = "ANcode"
+        flow._enrollment.async_register = AsyncMock(
+            return_value=_creds(customer_id="amzn1.account.OTHER")
         )
+        existing = MagicMock()
+        existing.entry_id = "entry123"
+        flow._reauth_entry = MagicMock(return_value=existing)
+        flow.async_set_unique_id = AsyncMock()
 
-    def test_error_form_includes_2fa_key_invalid_error(self):
-        """Test that the exception handler sets the correct error key."""
-        with open(
-            "custom_components/alexa_media/config_flow.py", encoding="utf-8"
-        ) as f:
-            content = f.read()
+        def _mismatch(reason):
+            raise Exception(reason)  # noqa: TRY002 — stand-in for AbortFlow
 
-        handler_start = content.find("except AlexapyPyotpInvalidKey:")
-        handler_block = content[handler_start : handler_start + 500]
+        flow._abort_if_unique_id_mismatch = MagicMock(side_effect=_mismatch)
+        with (
+            patch("custom_components.alexa_media.config_flow.SecureCredentialStore"),
+            pytest.raises(Exception, match="wrong_account"),
+        ):
+            await flow.async_step_paste({CONF_PASTE_URL: MAP_URL})
 
-        assert (
-            "2fa_key_invalid" in handler_block
-        ), "Error key '2fa_key_invalid' not found in exception handler"
 
-    def test_error_form_includes_otp_secret_placeholder(self):
-        """Test that the exception handler includes otp_secret in placeholders."""
-        with open(
-            "custom_components/alexa_media/config_flow.py", encoding="utf-8"
-        ) as f:
-            content = f.read()
-
-        handler_start = content.find("except AlexapyPyotpInvalidKey:")
-        handler_block = content[handler_start : handler_start + 500]
-
-        assert "otp_secret" in handler_block, (
-            "otp_secret placeholder not found in exception handler. "
-            "Users should see which OTP key was invalid."
-        )
-
-    def test_handler_returns_user_step(self):
-        """Test that the exception handler returns to the 'user' step."""
-        with open(
-            "custom_components/alexa_media/config_flow.py", encoding="utf-8"
-        ) as f:
-            content = f.read()
-
-        handler_start = content.find("except AlexapyPyotpInvalidKey:")
-        handler_block = content[handler_start : handler_start + 500]
-
-        assert 'step_id="user"' in handler_block, (
-            "step_id='user' not found in exception handler. "
-            "The handler should return users to the user step for correction."
-        )
+def test_config_version_bumped_for_migration():
+    """The schema version must advance so async_migrate_entry runs."""
+    assert CONFIG_VERSION == 2
+    assert AlexaMediaFlowHandler.VERSION == 2

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -153,6 +153,7 @@ class TestPasteStep:
         store = AsyncMock()
         tm = MagicMock()
         tm.async_refresh_access_token = AsyncMock()
+        tm.async_exchange_cookies = AsyncMock()
         with (
             patch(
                 "custom_components.alexa_media.config_flow.SecureCredentialStore",
@@ -166,8 +167,9 @@ class TestPasteStep:
             result = await flow.async_step_paste({CONF_PASTE_URL: MAP_URL})
 
         assert result["type"] == "create_entry"
-        # Credentials are validated before anything is persisted.
+        # Credentials are validated (refresh + cookie mint) before persisting.
         tm.async_refresh_access_token.assert_awaited_once()
+        tm.async_exchange_cookies.assert_awaited_once()
         # Entry is bound to the Amazon account id.
         flow.async_set_unique_id.assert_awaited_once_with("amzn1.account.ABC")
         # Credentials go to the protected store, never the entry data.
@@ -185,6 +187,7 @@ class TestReauth:
     def _paste_patches(store):
         tm = MagicMock()
         tm.async_refresh_access_token = AsyncMock()
+        tm.async_exchange_cookies = AsyncMock()
         return (
             patch(
                 "custom_components.alexa_media.config_flow.SecureCredentialStore",
@@ -259,6 +262,7 @@ class TestReauth:
         flow.async_abort = MagicMock(return_value={"type": "abort"})
         flow.hass.config_entries.async_update_entry = MagicMock()
         flow.hass.config_entries.async_reload = AsyncMock()
+        flow.hass.config_entries.async_entries = MagicMock(return_value=[existing])
         store = AsyncMock()
         p1, p2 = self._paste_patches(store)
         with p1, p2:
@@ -270,6 +274,40 @@ class TestReauth:
             flow.hass.config_entries.async_update_entry.call_args.kwargs["unique_id"]
             == "amzn1.account.ABC"
         )
+
+    @pytest.mark.asyncio
+    async def test_reauth_legacy_rebind_collision_aborts(self):
+        """Rebinding a legacy entry must not collide with another account entry."""
+        flow = AlexaMediaFlowHandler()
+        flow.hass = MagicMock()
+        flow.config.update(
+            {"email": "user@example.com", "url": "amazon.com", "reauth": True}
+        )
+        flow._enrollment = MagicMock()
+        flow._enrollment.parse_redirect_url.return_value = "ANcode"
+        flow._enrollment.async_register = AsyncMock(return_value=_creds())
+        existing = MagicMock()
+        existing.entry_id = "entry123"
+        existing.unique_id = "user@example.com - amazon.com"  # legacy
+        other = MagicMock()
+        other.entry_id = "entry999"
+        other.unique_id = "amzn1.account.ABC"  # already owns the account id
+        flow._reauth_entry = MagicMock(return_value=existing)
+        flow.async_set_unique_id = AsyncMock()
+        flow._abort_if_unique_id_mismatch = MagicMock()
+        flow.async_abort = MagicMock(return_value={"type": "abort"})
+        flow.hass.config_entries.async_entries = MagicMock(
+            return_value=[existing, other]
+        )
+        flow.hass.config_entries.async_update_entry = MagicMock()
+        store = AsyncMock()
+        p1, p2 = self._paste_patches(store)
+        with p1, p2:
+            result = await flow.async_step_paste({CONF_PASTE_URL: MAP_URL})
+
+        flow.async_abort.assert_called_once_with(reason="already_configured")
+        flow.hass.config_entries.async_update_entry.assert_not_called()
+        assert result["type"] == "abort"
 
     @pytest.mark.asyncio
     async def test_reauth_wrong_account_aborts(self):

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -2,7 +2,7 @@
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from alexapy import EnrollmentError
+from alexapy import AuthTransientError, EnrollmentError
 import pytest
 
 from custom_components.alexa_media.config_flow import (
@@ -64,6 +64,21 @@ class TestUserStep:
         assert result["step_id"] == "paste"
         assert "amazon.com/ap/register" in result["description_placeholders"]["url"]
 
+    @pytest.mark.asyncio
+    async def test_unsupported_domain_reprompts(self):
+        flow = AlexaMediaFlowHandler()
+        flow.hass = MagicMock()
+        with patch(
+            "custom_components.alexa_media.config_flow.EnrollmentFlow",
+            side_effect=EnrollmentError("Unsupported Amazon domain 'evil.example'"),
+        ):
+            result = await flow.async_step_user(
+                {"email": "user@example.com", "url": "evil.example"}
+            )
+        assert result["type"] == "form"
+        assert result["step_id"] == "user"
+        assert result["errors"] == {"base": "invalid_domain"}
+
 
 class TestPasteStep:
     """Step 2: parse the pasted redirect URL and register the device."""
@@ -101,6 +116,29 @@ class TestPasteStep:
         assert result["errors"] == {"base": "register_failed"}
 
     @pytest.mark.asyncio
+    async def test_missing_customer_id_rejected(self):
+        flow = self._flow_at_paste()
+        flow._enrollment.parse_redirect_url.return_value = "ANcode"
+        flow._enrollment.async_register = AsyncMock(
+            return_value=_creds(customer_id=None)
+        )
+        result = await flow.async_step_paste({CONF_PASTE_URL: MAP_URL})
+        assert result["errors"] == {"base": "register_failed"}
+
+    @pytest.mark.asyncio
+    async def test_transient_validation_shows_try_again(self):
+        flow = self._flow_at_paste()
+        flow._enrollment.parse_redirect_url.return_value = "ANcode"
+        flow._enrollment.async_register = AsyncMock(return_value=_creds())
+        tm = MagicMock()
+        tm.async_refresh_access_token = AsyncMock(side_effect=AuthTransientError("net"))
+        with patch(
+            "custom_components.alexa_media.config_flow.TokenManager", return_value=tm
+        ):
+            result = await flow.async_step_paste({CONF_PASTE_URL: MAP_URL})
+        assert result["errors"] == {"base": "try_again"}
+
+    @pytest.mark.asyncio
     async def test_success_creates_entry_and_stores_creds(self):
         flow = self._flow_at_paste()
         flow._enrollment.parse_redirect_url.return_value = "ANcode"
@@ -113,13 +151,23 @@ class TestPasteStep:
             return_value={"type": "create_entry", "result": created}
         )
         store = AsyncMock()
-        with patch(
-            "custom_components.alexa_media.config_flow.SecureCredentialStore",
-            return_value=store,
+        tm = MagicMock()
+        tm.async_refresh_access_token = AsyncMock()
+        with (
+            patch(
+                "custom_components.alexa_media.config_flow.SecureCredentialStore",
+                return_value=store,
+            ),
+            patch(
+                "custom_components.alexa_media.config_flow.TokenManager",
+                return_value=tm,
+            ),
         ):
             result = await flow.async_step_paste({CONF_PASTE_URL: MAP_URL})
 
         assert result["type"] == "create_entry"
+        # Credentials are validated before anything is persisted.
+        tm.async_refresh_access_token.assert_awaited_once()
         # Entry is bound to the Amazon account id.
         flow.async_set_unique_id.assert_awaited_once_with("amzn1.account.ABC")
         # Credentials go to the protected store, never the entry data.
@@ -133,6 +181,21 @@ class TestPasteStep:
 class TestReauth:
     """Reauth must re-enroll and must not rebind to a different account."""
 
+    @staticmethod
+    def _paste_patches(store):
+        tm = MagicMock()
+        tm.async_refresh_access_token = AsyncMock()
+        return (
+            patch(
+                "custom_components.alexa_media.config_flow.SecureCredentialStore",
+                return_value=store,
+            ),
+            patch(
+                "custom_components.alexa_media.config_flow.TokenManager",
+                return_value=tm,
+            ),
+        )
+
     @pytest.mark.asyncio
     async def test_reauth_routes_to_user_step(self):
         flow = AlexaMediaFlowHandler()
@@ -143,7 +206,7 @@ class TestReauth:
         assert flow.config["reauth"] is True
 
     @pytest.mark.asyncio
-    async def test_reauth_success_updates_and_reloads(self):
+    async def test_reauth_success_rebinds_and_reloads(self):
         flow = AlexaMediaFlowHandler()
         flow.hass = MagicMock()
         flow.config.update(
@@ -154,6 +217,7 @@ class TestReauth:
         flow._enrollment.async_register = AsyncMock(return_value=_creds())
         existing = MagicMock()
         existing.entry_id = "entry123"
+        existing.unique_id = "amzn1.account.ABC"  # already account-bound, same acct
         flow._reauth_entry = MagicMock(return_value=existing)
         flow.async_set_unique_id = AsyncMock()
         flow._abort_if_unique_id_mismatch = MagicMock()
@@ -161,16 +225,51 @@ class TestReauth:
         flow.hass.config_entries.async_update_entry = MagicMock()
         flow.hass.config_entries.async_reload = AsyncMock()
         store = AsyncMock()
-        with patch(
-            "custom_components.alexa_media.config_flow.SecureCredentialStore",
-            return_value=store,
-        ):
+        p1, p2 = self._paste_patches(store)
+        with p1, p2:
             result = await flow.async_step_paste({CONF_PASTE_URL: MAP_URL})
 
         flow._abort_if_unique_id_mismatch.assert_called_once()
+        # Entry is (re)written with the account-id unique_id.
+        assert (
+            flow.hass.config_entries.async_update_entry.call_args.kwargs["unique_id"]
+            == "amzn1.account.ABC"
+        )
         flow.hass.config_entries.async_reload.assert_awaited_once_with("entry123")
         flow.async_abort.assert_called_once_with(reason="reauth_successful")
         assert result["type"] == "abort"
+
+    @pytest.mark.asyncio
+    async def test_reauth_binds_legacy_entry_without_mismatch(self):
+        """A legacy entry keyed by '<email> - <region>' must rebind, not abort."""
+        flow = AlexaMediaFlowHandler()
+        flow.hass = MagicMock()
+        flow.config.update(
+            {"email": "user@example.com", "url": "amazon.com", "reauth": True}
+        )
+        flow._enrollment = MagicMock()
+        flow._enrollment.parse_redirect_url.return_value = "ANcode"
+        flow._enrollment.async_register = AsyncMock(return_value=_creds())
+        existing = MagicMock()
+        existing.entry_id = "entry123"
+        existing.unique_id = "user@example.com - amazon.com"  # legacy unique_id
+        flow._reauth_entry = MagicMock(return_value=existing)
+        flow.async_set_unique_id = AsyncMock()
+        flow._abort_if_unique_id_mismatch = MagicMock()
+        flow.async_abort = MagicMock(return_value={"type": "abort"})
+        flow.hass.config_entries.async_update_entry = MagicMock()
+        flow.hass.config_entries.async_reload = AsyncMock()
+        store = AsyncMock()
+        p1, p2 = self._paste_patches(store)
+        with p1, p2:
+            await flow.async_step_paste({CONF_PASTE_URL: MAP_URL})
+
+        # No mismatch check for a legacy entry; it is rebound to the account id.
+        flow._abort_if_unique_id_mismatch.assert_not_called()
+        assert (
+            flow.hass.config_entries.async_update_entry.call_args.kwargs["unique_id"]
+            == "amzn1.account.ABC"
+        )
 
     @pytest.mark.asyncio
     async def test_reauth_wrong_account_aborts(self):
@@ -186,6 +285,7 @@ class TestReauth:
         )
         existing = MagicMock()
         existing.entry_id = "entry123"
+        existing.unique_id = "amzn1.account.ABC"  # account-bound to a different acct
         flow._reauth_entry = MagicMock(return_value=existing)
         flow.async_set_unique_id = AsyncMock()
 
@@ -193,10 +293,9 @@ class TestReauth:
             raise Exception(reason)  # noqa: TRY002 — stand-in for AbortFlow
 
         flow._abort_if_unique_id_mismatch = MagicMock(side_effect=_mismatch)
-        with (
-            patch("custom_components.alexa_media.config_flow.SecureCredentialStore"),
-            pytest.raises(Exception, match="wrong_account"),
-        ):
+        store = AsyncMock()
+        p1, p2 = self._paste_patches(store)
+        with p1, p2, pytest.raises(Exception, match="wrong_account"):
             await flow.async_step_paste({CONF_PASTE_URL: MAP_URL})
 
 

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -4,10 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from custom_components.alexa_media import (
-    _cleanup_legacy_secrets,
-    async_migrate_entry,
-)
+from custom_components.alexa_media import _cleanup_legacy_secrets, async_migrate_entry
 from custom_components.alexa_media.const import CONF_OAUTH, CONF_SECURE
 
 

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -1,0 +1,94 @@
+"""Tests for the lazy, non-destructive secure-schema migration."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.alexa_media import (
+    _cleanup_legacy_secrets,
+    async_migrate_entry,
+)
+from custom_components.alexa_media.const import CONF_OAUTH, CONF_SECURE
+
+
+def _entry(version=1, data=None):
+    entry = MagicMock()
+    entry.version = version
+    entry.entry_id = "entry123"
+    entry.data = data if data is not None else {}
+    return entry
+
+
+@pytest.mark.asyncio
+async def test_migrate_copies_tokens_and_keeps_legacy():
+    hass = MagicMock()
+    hass.config_entries.async_update_entry = MagicMock()
+    entry = _entry(
+        data={
+            "email": "user@example.com",
+            "url": "amazon.com",
+            "password": "secret",
+            "otp_secret": "SEED",
+            CONF_OAUTH: {"refresh_token": "r", "mac_dms": {"k": "v"}},
+        }
+    )
+    store = AsyncMock()
+    with patch(
+        "custom_components.alexa_media.SecureCredentialStore", return_value=store
+    ):
+        assert await async_migrate_entry(hass, entry) is True
+
+    # Tokens copied to the protected store, flagged pending until validated.
+    save_kwargs = store.async_save.call_args.kwargs
+    assert save_kwargs["pending_validation"] is True
+    # Entry marked secure and version bumped, but legacy secrets NOT yet removed.
+    update_kwargs = hass.config_entries.async_update_entry.call_args.kwargs
+    assert update_kwargs["data"][CONF_SECURE] is True
+    assert update_kwargs["version"] == 2
+    assert update_kwargs["data"]["password"] == "secret"
+
+
+@pytest.mark.asyncio
+async def test_migrate_without_token_marks_secure_for_reauth():
+    hass = MagicMock()
+    hass.config_entries.async_update_entry = MagicMock()
+    entry = _entry(data={"email": "user@example.com", "url": "amazon.com"})
+    with patch("custom_components.alexa_media.SecureCredentialStore") as store_cls:
+        assert await async_migrate_entry(hass, entry) is True
+        store_cls.assert_not_called()
+    update_kwargs = hass.config_entries.async_update_entry.call_args.kwargs
+    assert update_kwargs["data"][CONF_SECURE] is True
+    assert update_kwargs["version"] == 2
+
+
+@pytest.mark.asyncio
+async def test_migrate_noop_when_current_version():
+    hass = MagicMock()
+    hass.config_entries.async_update_entry = MagicMock()
+    entry = _entry(version=2)
+    assert await async_migrate_entry(hass, entry) is True
+    hass.config_entries.async_update_entry.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_cleanup_removes_legacy_secrets():
+    hass = MagicMock()
+    hass.config_entries.async_update_entry = MagicMock()
+    hass.config.path = MagicMock(return_value="/nonexistent/cookie.pickle")
+    entry = _entry(
+        data={
+            "email": "user@example.com",
+            "url": "amazon.com",
+            "password": "secret",
+            "otp_secret": "SEED",
+            CONF_OAUTH: {"refresh_token": "r"},
+            CONF_SECURE: True,
+        }
+    )
+    with patch("custom_components.alexa_media.os.path.exists", return_value=False):
+        await _cleanup_legacy_secrets(hass, entry)
+    new_data = hass.config_entries.async_update_entry.call_args.kwargs["data"]
+    assert "password" not in new_data
+    assert "otp_secret" not in new_data
+    assert CONF_OAUTH not in new_data
+    assert new_data[CONF_SECURE] is True

--- a/tests/test_remove_entry.py
+++ b/tests/test_remove_entry.py
@@ -1,0 +1,68 @@
+"""Tests for secure-entry teardown (best-effort deregister + store delete)."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.alexa_media import async_remove_entry
+from custom_components.alexa_media.const import CONF_SECURE
+
+
+def _secure_entry():
+    entry = MagicMock()
+    entry.entry_id = "entry123"
+    entry.data = {"email": "user@example.com", CONF_SECURE: True}
+    return entry
+
+
+@pytest.mark.asyncio
+async def test_remove_deregisters_and_deletes_store():
+    hass = MagicMock()
+    store = AsyncMock()
+    store.async_load = AsyncMock(
+        return_value={"refresh_token": "r", "mac_dms": {"k": "v"}, "serial": "S"}
+    )
+    manager = AsyncMock()
+    with (
+        patch(
+            "custom_components.alexa_media.SecureCredentialStore", return_value=store
+        ),
+        patch("alexapy.TokenManager", return_value=manager),
+        patch("alexapy.DeviceCredentials"),
+    ):
+        assert await async_remove_entry(hass, _secure_entry()) is True
+
+    manager.async_refresh_access_token.assert_awaited_once()
+    manager.async_deregister.assert_awaited_once()
+    store.async_remove.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_remove_survives_deregister_failure():
+    hass = MagicMock()
+    store = AsyncMock()
+    store.async_load = AsyncMock(return_value={"refresh_token": "r"})
+    manager = AsyncMock()
+    manager.async_refresh_access_token = AsyncMock(side_effect=RuntimeError("boom"))
+    with (
+        patch(
+            "custom_components.alexa_media.SecureCredentialStore", return_value=store
+        ),
+        patch("alexapy.TokenManager", return_value=manager),
+        patch("alexapy.DeviceCredentials"),
+    ):
+        # Amazon failure must never block removal.
+        assert await async_remove_entry(hass, _secure_entry()) is True
+    store.async_remove.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_remove_without_stored_creds_still_deletes_store():
+    hass = MagicMock()
+    store = AsyncMock()
+    store.async_load = AsyncMock(return_value=None)
+    with patch(
+        "custom_components.alexa_media.SecureCredentialStore", return_value=store
+    ):
+        assert await async_remove_entry(hass, _secure_entry()) is True
+    store.async_remove.assert_awaited_once()

--- a/tests/test_secure_store.py
+++ b/tests/test_secure_store.py
@@ -1,0 +1,81 @@
+"""Tests for the protected credential store."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.alexa_media.secure_store import (
+    CREDENTIAL_KEYS,
+    SecureCredentialStore,
+)
+
+
+def _store_with_backing():
+    backing = MagicMock()
+    backing.async_load = AsyncMock(return_value=None)
+    backing.async_save = AsyncMock()
+    backing.async_remove = AsyncMock()
+    backing.key = "alexa_media.secure_credentials.entry123"
+    with patch(
+        "custom_components.alexa_media.secure_store.Store", return_value=backing
+    ):
+        store = SecureCredentialStore(MagicMock(), "entry123")
+    return store, backing
+
+
+def test_store_created_private_and_atomic():
+    with patch("custom_components.alexa_media.secure_store.Store") as store_cls:
+        SecureCredentialStore(MagicMock(), "entry123")
+    _args, kwargs = store_cls.call_args
+    assert kwargs["private"] is True
+    assert kwargs["atomic_writes"] is True
+
+
+@pytest.mark.asyncio
+async def test_save_persists_only_known_keys():
+    store, backing = _store_with_backing()
+    await store.async_save(
+        {
+            "refresh_token": "r",
+            "mac_dms": {"k": "v"},
+            "serial": "S",
+            "customer_id": "C",
+            "domain": "amazon.com",
+            "password": "leak",  # must be dropped
+        },
+        pending_validation=True,
+    )
+    payload = backing.async_save.call_args.args[0]
+    assert "password" not in payload
+    assert set(payload) == set(CREDENTIAL_KEYS) | {"pending_validation"}
+    assert payload["pending_validation"] is True
+
+
+@pytest.mark.asyncio
+async def test_mark_validated_clears_flag():
+    store, backing = _store_with_backing()
+    backing.async_load = AsyncMock(
+        return_value={"refresh_token": "r", "pending_validation": True}
+    )
+    store._data = None
+    await store.async_mark_validated()
+    payload = backing.async_save.call_args.args[0]
+    assert payload["pending_validation"] is False
+
+
+@pytest.mark.asyncio
+async def test_mark_validated_noop_when_not_pending():
+    store, backing = _store_with_backing()
+    backing.async_load = AsyncMock(
+        return_value={"refresh_token": "r", "pending_validation": False}
+    )
+    store._data = None
+    await store.async_mark_validated()
+    backing.async_save.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_remove_delegates_to_backing():
+    store, backing = _store_with_backing()
+    await store.async_remove()
+    backing.async_remove.assert_awaited_once()


### PR DESCRIPTION
> **Draft — blocked on the alexapy release.** This PR imports new primitives from
> `alexapy` (the `secureauth` module) and pins `alexapy==1.30.0`, the release that
> will carry them. Until that alexapy is published, CI is red at the install step.
> The library half is keatontaylor/alexapy!477. Opening this now for
> visibility/review under RFC #3523, not for merge.

Implements the enrollment-only auth redesign from #3523: stop persisting the
password and the TOTP seed, drive the interactive login through Amazon's own
page, and store only minimized device credentials in a dedicated protected store.

## What changes

- **Two-step config flow.** Collect account email + region, then have the user
  log in on Amazon's real page and paste the `/ap/maplanding` redirect URL. No
  password, OTP, or Authenticator key is entered in Home Assistant. The blank
  maplanding page is expected and the code expires in ~5 minutes (stated in the
  step text).
- **Account binding.** Enrollment sets the config entry `unique_id` to the Amazon
  account id from the exchange; reauth uses `_abort_if_unique_id_mismatch` so a
  pasted URL for a different account can't rebind the entry. A legacy entry keyed
  by `<email> - <region>` is rebound to the account id on first reauth (with a
  duplicate-collision guard).
- **Protected store.** `SecureCredentialStore` wraps
  `Store(private=True, atomic_writes=True)` and holds only `refresh_token`,
  `mac_dms`, `serial`, `customer_id`, `domain` — excluded from the config entry
  and from diagnostics. This is file-permission hygiene, not host-compromise
  protection: `.storage` is in HA backups.
- **Runtime.** Every start preflights the stored credentials through
  `TokenManager` (refresh + cookie mint), which classifies failures:
  `AuthTerminalError` → `ConfigEntryAuthFailed` (starts the paste-URL reauth
  flow), transient/network/5xx → `ConfigEntryNotReady` (retry). No legacy cookie
  file is read. Rotated tokens are written back only to the protected store.
- **Migration (v1→v2), local/lazy/non-destructive.** `async_migrate_entry` copies
  an existing `refresh_token`/`mac_dms` into the protected store and marks the
  entry secure, but keeps the legacy secrets until the first successful refresh
  commits; only then are the password, otp_secret, inline oauth, and legacy
  cookie files deleted. No Amazon request happens during migration.
- **Teardown.** `async_remove_entry` does a best-effort `/auth/deregister`, then
  deletes the protected store (with a direct-unlink fallback); Amazon
  availability never blocks removal.
- **Diagnostics/strings.** Redaction extended (`serial`, `customer_id`,
  `paste_url`); strings + `en.json` updated for the paste step and new error
  keys; `authcaptureproxy` dropped from loggers.

## Notes for review

- **Breaking change** (hence `feat!`): the proxy/TOTP enrollment and cookie-file
  persistence are removed. The version is left to semantic-release; the migration
  path handles existing entries.
- **Reverse-engineered, unsupported endpoints** (same family alexapy already
  uses); refresh-token lifetime/revocation have no published guarantee.
- **Tests:** new config-flow (user/paste/reauth/account-mismatch), secure store,
  migration, and remove-entry suites. Full integration suite green except two
  diagnostics tests that also fail on unpatched `dev` in this environment (HA
  frame helper needs a running hass) — pre-existing, unrelated.

## Depends on

- keatontaylor/alexapy!477 (the `secureauth` module), released as
  `alexapy==1.30.0` (adjust the pin to the exact tag if it differs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
