### PR TITLE
feat: add Amazon Kids (child mode) support

### DIFF
--- a/custom_components/alexa_media/binary_sensor.py
+++ b/custom_components/alexa_media/binary_sensor.py
@@ -7,14 +7,16 @@ For more details about this platform, please refer to the documentation at
 https://community.home-assistant.io/t/echo-devices-alexa-as-media-player-testers-needed/58639
 """
 
+from datetime import timedelta
 import logging
 
-from alexapy import hide_serial
+from alexapy import AlexaAPI, hide_serial
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
     BinarySensorEntity,
 )
 from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import (
@@ -26,9 +28,12 @@ from . import (
 )
 from .alexa_entity import parse_detection_state_from_coordinator
 from .const import CONF_EXTENDED_ENTITY_DISCOVERY
-from .helpers import add_devices, safe_get
+from .helpers import _catch_login_errors, add_devices, safe_get
 
 _LOGGER = logging.getLogger(__name__)
+
+KIDS_SCAN_INTERVAL = timedelta(minutes=5)
+KIDS_CAPABLE_FAMILIES = {"ECHO", "ROOK", "KNIGHT", "REAVER", "MANTIS"}
 
 
 async def async_setup_platform(hass, config, add_devices_callback, discovery_info=None):
@@ -56,6 +61,21 @@ async def async_setup_platform(hass, config, add_devices_callback, discovery_inf
             contact_sensor = AlexaContact(coordinator, binary_entity)
             account_dict["entities"]["binary_sensor"].append(contact_sensor)
             devices.append(contact_sensor)
+
+    # Amazon Kids (child mode) sensor per Echo device
+    login_obj = account_dict["login_obj"]
+    for key, device in account_dict["devices"]["media_player"].items():
+        if device.get("deviceFamily") not in KIDS_CAPABLE_FAMILIES:
+            continue
+        device_type = device.get("deviceType")
+        if not device_type:
+            continue
+        serial = device.get("serialNumber") or key
+        kids_sensor = AmazonKidsSensor(
+            login_obj, serial, device_type, device.get("accountName") or serial
+        )
+        account_dict["entities"]["binary_sensor"].append(kids_sensor)
+        devices.append(kids_sensor)
 
     return await add_devices(
         hide_email(account),
@@ -126,3 +146,67 @@ class AlexaContact(CoordinatorEntity, BinarySensorEntity):
             self.coordinator.data and self.alexa_entity_id in self.coordinator.data
         )
         return not last_refresh_success
+
+
+class AmazonKidsSensor(BinarySensorEntity):
+    """Whether Amazon Kids (child mode) is active on an Echo device.
+
+    Polls the per-device ``isChildDirectedDevice`` state via alexapy on its own
+    interval (independent of the main coordinator).
+    """
+
+    _attr_has_entity_name = True
+    _attr_name = "Amazon Kids"
+    _attr_icon = "mdi:account-child"
+    _attr_should_poll = False
+
+    def __init__(self, login, serial: str, device_type: str, name: str) -> None:
+        """Initialize the Amazon Kids sensor."""
+        self._login = login
+        self._serial = serial
+        self._device_type = device_type
+        self._dev_name = name
+        self._state = None
+
+    @property
+    def unique_id(self):
+        """Return the unique id."""
+        return f"{self._serial}_amazon_kids"
+
+    @property
+    def is_on(self):
+        """Return whether Amazon Kids is active."""
+        return self._state
+
+    @property
+    def available(self):
+        """Return whether the state is known."""
+        return self._state is not None
+
+    @property
+    def device_info(self):
+        """Attach to the Echo device."""
+        return {
+            "identifiers": {(DATA_ALEXAMEDIA, self._serial)},
+            "via_device": (DATA_ALEXAMEDIA, self._serial),
+        }
+
+    async def async_added_to_hass(self):
+        """Do an initial refresh and schedule periodic updates."""
+        await self._async_refresh()
+        self.async_on_remove(
+            async_track_time_interval(
+                self.hass, self._async_interval, KIDS_SCAN_INTERVAL
+            )
+        )
+
+    async def _async_interval(self, now):
+        await self._async_refresh()
+
+    @_catch_login_errors
+    async def _async_refresh(self):
+        """Fetch the current Amazon Kids state."""
+        self._state = await AlexaAPI.get_child_mode(
+            self._login, self._serial, self._device_type
+        )
+        self.async_write_ha_state()

--- a/custom_components/alexa_media/binary_sensor.py
+++ b/custom_components/alexa_media/binary_sensor.py
@@ -62,28 +62,38 @@ async def async_setup_platform(hass, config, add_devices_callback, discovery_inf
             account_dict["entities"]["binary_sensor"].append(contact_sensor)
             devices.append(contact_sensor)
 
-    # Amazon Kids (child mode) sensor per Echo device
+    # Amazon Kids (child mode) sensor per Echo device.
+    # Only create a sensor for Echos that already have a media_player entity, so
+    # the configured include/exclude device filters are inherited and the unique
+    # id can be scoped to the account exactly like the media player.
     login_obj = account_dict["login_obj"]
+    media_players = account_dict["entities"]["media_player"]
+    kids_devices: list[BinarySensorEntity] = []
     for key, device in account_dict["devices"]["media_player"].items():
         if device.get("deviceFamily") not in KIDS_CAPABLE_FAMILIES:
             continue
         device_type = device.get("deviceType")
-        if not device_type:
+        client = media_players.get(key)
+        if not device_type or client is None:
             continue
-        serial = device.get("serialNumber") or key
-        kids_sensor = AmazonKidsSensor(
-            login_obj, serial, device_type, device.get("accountName") or serial
-        )
+        kids_sensor = AmazonKidsSensor(login_obj, client, device_type)
         account_dict["entities"]["binary_sensor"].append(kids_sensor)
-        devices.append(kids_sensor)
+        kids_devices.append(kids_sensor)
 
-    return await add_devices(
+    result = await add_devices(
         hide_email(account),
         devices,
         add_devices_callback,
         include_filter,
         exclude_filter,
     )
+    if kids_devices:
+        # Already scoped via the media_player entities, so no extra name filter.
+        result = (
+            await add_devices(hide_email(account), kids_devices, add_devices_callback)
+            and result
+        )
+    return result
 
 
 async def async_setup_entry(hass, config_entry, async_add_devices):
@@ -160,18 +170,22 @@ class AmazonKidsSensor(BinarySensorEntity):
     _attr_icon = "mdi:account-child"
     _attr_should_poll = False
 
-    def __init__(self, login, serial: str, device_type: str, name: str) -> None:
-        """Initialize the Amazon Kids sensor."""
+    def __init__(self, login, client, device_type: str) -> None:
+        """Initialize the Amazon Kids sensor.
+
+        client is the Echo's media_player entity; its unique id already encodes
+        the account, so the sensor inherits the same (account-scoped) identity.
+        """
         self._login = login
-        self._serial = serial
+        self._client = client
+        self._serial = client.device_serial_number
         self._device_type = device_type
-        self._dev_name = name
         self._state = None
 
     @property
     def unique_id(self):
-        """Return the unique id."""
-        return f"{self._serial}_amazon_kids"
+        """Return the unique id, scoped to the account like the media player."""
+        return f"{self._client.unique_id}_amazon_kids"
 
     @property
     def is_on(self):
@@ -187,8 +201,8 @@ class AmazonKidsSensor(BinarySensorEntity):
     def device_info(self):
         """Attach to the Echo device."""
         return {
-            "identifiers": {(DATA_ALEXAMEDIA, self._serial)},
-            "via_device": (DATA_ALEXAMEDIA, self._serial),
+            "identifiers": {(DATA_ALEXAMEDIA, self._client.unique_id)},
+            "via_device": (DATA_ALEXAMEDIA, self._client.unique_id),
         }
 
     async def async_added_to_hass(self):

--- a/custom_components/alexa_media/const.py
+++ b/custom_components/alexa_media/const.py
@@ -78,6 +78,8 @@ SERVICE_RESTORE_VOLUME = "restore_volume"
 SERVICE_GET_HISTORY_RECORDS = "get_history_records"
 SERVICE_FORCE_LOGOUT = "force_logout"
 SERVICE_ENABLE_NETWORK_DISCOVERY = "enable_network_discovery"
+SERVICE_AMAZON_KIDS_ENABLE = "amazon_kids_enable"
+SERVICE_AMAZON_KIDS_DISABLE = "amazon_kids_disable"
 
 # Backoff durations for the last-called probe worker
 LAST_CALLED_429_BACKOFF_INITIAL_S = 30.0
@@ -147,6 +149,7 @@ ATTR_MESSAGE = "message"
 ATTR_EMAIL = "email"
 ATTR_ENTITY_ID = "entity_id"
 ATTR_NUM_ENTRIES = "entries"
+ATTR_CHILD = "child"
 COMMON_BUCKET_COUNTS = (
     "accounts",
     "devices",

--- a/custom_components/alexa_media/manifest.json
+++ b/custom_components/alexa_media/manifest.json
@@ -9,7 +9,7 @@
   "issue_tracker": "https://github.com/alandtse/alexa_media_player/issues",
   "loggers": ["alexapy", "authcaptureproxy"],
   "requirements": [
-    "alexapy==1.29.25",
+    "alexapy==1.30.0",
     "packaging>=20.3",
     "wrapt>=1.14.0",
     "dictor>=0.1.12,<0.2"

--- a/custom_components/alexa_media/services.py
+++ b/custom_components/alexa_media/services.py
@@ -16,6 +16,7 @@ from alexapy import AlexaAPI, AlexapyLoginError, hide_email
 from alexapy.errors import AlexapyConnectionError
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers import config_validation as cv, entity_registry as er
+from homeassistant.util import slugify
 import voluptuous as vol
 
 from .const import (
@@ -304,11 +305,16 @@ class AlexaMediaServices:
         if not entity_entry or entity_entry.platform != DOMAIN:
             _LOGGER.error("Entity %s not found or not part of %s", entity_id, DOMAIN)
             return None, None, None
-        serial = entity_entry.unique_id
+        unique_id = entity_entry.unique_id
         accounts = self.hass.data[DATA_ALEXAMEDIA]["accounts"]
         for email, account_dict in accounts.items():
             for device in AlexaAPI.devices.get(email, []):
-                if device.get("serialNumber") == serial:
+                serial = device.get("serialNumber")
+                if not serial:
+                    continue
+                # Match the media_player unique id convention: raw serial for the
+                # primary account, slugify("<serial>_<email>") for secondaries.
+                if unique_id in (serial, slugify(f"{serial}_{email}")):
                     return account_dict["login_obj"], serial, device.get("deviceType")
         _LOGGER.error("No Alexa Media account/device found for entity %s", entity_id)
         return None, None, None

--- a/custom_components/alexa_media/services.py
+++ b/custom_components/alexa_media/services.py
@@ -19,11 +19,14 @@ from homeassistant.helpers import config_validation as cv, entity_registry as er
 import voluptuous as vol
 
 from .const import (
+    ATTR_CHILD,
     ATTR_EMAIL,
     ATTR_ENTITY_ID,
     ATTR_NUM_ENTRIES,
     DATA_ALEXAMEDIA,
     DOMAIN,
+    SERVICE_AMAZON_KIDS_DISABLE,
+    SERVICE_AMAZON_KIDS_ENABLE,
     SERVICE_ENABLE_NETWORK_DISCOVERY,
     SERVICE_FORCE_LOGOUT,
     SERVICE_GET_HISTORY_RECORDS,
@@ -58,6 +61,14 @@ ENABLE_NETWORK_DISCOVERY_SCHEMA = vol.Schema(
         ),
     }
 )
+
+AMAZON_KIDS_ENABLE_SCHEMA = vol.Schema(
+    {
+        vol.Required(ATTR_ENTITY_ID): cv.entity_id,
+        vol.Required(ATTR_CHILD): cv.string,
+    }
+)
+AMAZON_KIDS_DISABLE_SCHEMA = vol.Schema({vol.Required(ATTR_ENTITY_ID): cv.entity_id})
 
 
 @dataclass(frozen=True)
@@ -94,6 +105,16 @@ SERVICE_DEFS: tuple[AlexaServiceDef, ...] = (
         name=SERVICE_ENABLE_NETWORK_DISCOVERY,
         schema=ENABLE_NETWORK_DISCOVERY_SCHEMA,
         handler="enable_network_discovery",
+    ),
+    AlexaServiceDef(
+        name=SERVICE_AMAZON_KIDS_ENABLE,
+        schema=AMAZON_KIDS_ENABLE_SCHEMA,
+        handler="amazon_kids_enable",
+    ),
+    AlexaServiceDef(
+        name=SERVICE_AMAZON_KIDS_DISABLE,
+        schema=AMAZON_KIDS_DISABLE_SCHEMA,
+        handler="amazon_kids_disable",
     ),
 )
 
@@ -274,6 +295,70 @@ class AlexaMediaServices:
         )
 
         _LOGGER.debug("Volume restored to %s for entity %s", previous_volume, entity_id)
+        return True
+
+    def _resolve_device(self, entity_id):
+        """Resolve a media_player entity_id to (login_obj, serial, device_type)."""
+        entity_registry = er.async_get(self.hass)
+        entity_entry = entity_registry.async_get(entity_id)
+        if not entity_entry or entity_entry.platform != DOMAIN:
+            _LOGGER.error("Entity %s not found or not part of %s", entity_id, DOMAIN)
+            return None, None, None
+        serial = entity_entry.unique_id
+        accounts = self.hass.data[DATA_ALEXAMEDIA]["accounts"]
+        for email, account_dict in accounts.items():
+            for device in AlexaAPI.devices.get(email, []):
+                if device.get("serialNumber") == serial:
+                    return account_dict["login_obj"], serial, device.get("deviceType")
+        _LOGGER.error("No Alexa Media account/device found for entity %s", entity_id)
+        return None, None, None
+
+    async def _resolve_child_id(self, login_obj, child):
+        """Resolve a child (directedId or first name) to its directedId."""
+        if child and child.startswith("amzn1.account"):
+            return child
+        profiles = await AlexaAPI.get_child_profiles(login_obj) or []
+        for profile in profiles:
+            if (profile.get("firstName") or "").lower() == (child or "").lower():
+                return profile.get("directedId")
+        _LOGGER.error("Child profile '%s' not found in household", child)
+        return None
+
+    @_catch_login_errors
+    async def amazon_kids_enable(self, call: ServiceCall) -> bool:
+        """Enable Amazon Kids on a device by assigning it to a child profile.
+
+        Arguments:
+            call.ATTR_ENTITY_ID {str} -- Alexa Media Player entity.
+            call.ATTR_CHILD {str} -- Child first name or directedId.
+
+        """
+        entity_id = call.data.get(ATTR_ENTITY_ID)
+        child = call.data.get(ATTR_CHILD)
+        login_obj, serial, device_type = self._resolve_device(entity_id)
+        if not login_obj:
+            return False
+        child_id = await self._resolve_child_id(login_obj, child)
+        if not child_id:
+            return False
+        await AlexaAPI.enable_child_mode(login_obj, serial, device_type, child_id)
+        _LOGGER.debug("Enabled Amazon Kids on %s for child %s", entity_id, child)
+        return True
+
+    @_catch_login_errors
+    async def amazon_kids_disable(self, call: ServiceCall) -> bool:
+        """Disable Amazon Kids on a device (unassign it from any child).
+
+        Arguments:
+            call.ATTR_ENTITY_ID {str} -- Alexa Media Player entity.
+
+        """
+        entity_id = call.data.get(ATTR_ENTITY_ID)
+        login_obj, serial, device_type = self._resolve_device(entity_id)
+        if not login_obj:
+            return False
+        await AlexaAPI.disable_child_mode(login_obj, serial, device_type)
+        _LOGGER.debug("Disabled Amazon Kids on %s", entity_id)
         return True
 
     async def get_history_records(self, call: ServiceCall) -> bool:

--- a/custom_components/alexa_media/services.yaml
+++ b/custom_components/alexa_media/services.yaml
@@ -68,3 +68,36 @@ enable_network_discovery:
       example: [email protected]
       selector:
         text:
+
+amazon_kids_enable:
+  name: Enable Amazon Kids
+  description: Enable Amazon Kids (child mode) on an Echo by assigning it to a child profile.
+  fields:
+    entity_id:
+      name: Entity
+      description: Alexa Media Player device to enable Amazon Kids on.
+      required: true
+      selector:
+        entity:
+          domain: media_player
+          integration: alexa_media
+    child:
+      name: Child
+      description: Child profile first name (or directedId) to assign the device to.
+      required: true
+      example: "Anton"
+      selector:
+        text:
+
+amazon_kids_disable:
+  name: Disable Amazon Kids
+  description: Disable Amazon Kids (child mode) on an Echo by unassigning it from any child.
+  fields:
+    entity_id:
+      name: Entity
+      description: Alexa Media Player device to disable Amazon Kids on.
+      required: true
+      selector:
+        entity:
+          domain: media_player
+          integration: alexa_media

--- a/custom_components/alexa_media/strings.json
+++ b/custom_components/alexa_media/strings.json
@@ -132,6 +132,30 @@
           "description": "Optional Alexa account email or list of emails. If empty, all known accounts will be refreshed."
         }
       }
+    },
+    "amazon_kids_enable": {
+      "name": "Enable Amazon Kids",
+      "description": "Turns on Amazon Kids (child mode) for an Echo by assigning it to a child profile.",
+      "fields": {
+        "entity_id": {
+          "name": "Select media player:",
+          "description": "Echo device to enable Amazon Kids on"
+        },
+        "child": {
+          "name": "Child",
+          "description": "Child profile to assign (first name or directedId)"
+        }
+      }
+    },
+    "amazon_kids_disable": {
+      "name": "Disable Amazon Kids",
+      "description": "Turns off Amazon Kids (child mode) for an Echo by unassigning it from any child profile.",
+      "fields": {
+        "entity_id": {
+          "name": "Select media player:",
+          "description": "Echo device to disable Amazon Kids on"
+        }
+      }
     }
   },
   "entity": {

--- a/custom_components/alexa_media/translations/en.json
+++ b/custom_components/alexa_media/translations/en.json
@@ -130,6 +130,30 @@
     }
   },
   "services": {
+    "amazon_kids_disable": {
+      "description": "Turns off Amazon Kids (child mode) for an Echo by unassigning it from any child profile.",
+      "fields": {
+        "entity_id": {
+          "description": "Echo device to disable Amazon Kids on",
+          "name": "Select media player:"
+        }
+      },
+      "name": "Disable Amazon Kids"
+    },
+    "amazon_kids_enable": {
+      "description": "Turns on Amazon Kids (child mode) for an Echo by assigning it to a child profile.",
+      "fields": {
+        "child": {
+          "description": "Child profile to assign (first name or directedId)",
+          "name": "Child"
+        },
+        "entity_id": {
+          "description": "Echo device to enable Amazon Kids on",
+          "name": "Select media player:"
+        }
+      },
+      "name": "Enable Amazon Kids"
+    },
     "enable_network_discovery": {
       "description": "Re-enables Alexa network discovery so the next polling cycle will rediscover Alexa devices for the selected accounts.",
       "fields": {


### PR DESCRIPTION
## Summary
Adds Home Assistant support for **Amazon Kids** (child mode) on Echo devices, using the new alexapy `AlexaAPI` methods (released in alexapy 1.30.0, keatontaylor/alexapy!472).

Closes #349.

## What's added
- **`binary_sensor.<echo>_amazon_kids`** — reflects the per-device `isChildDirectedDevice` state (polled on its own 5-minute interval).
- **`alexa_media.amazon_kids_enable`** (`entity_id`, `child`) — assigns an Echo to a child profile (turns Amazon Kids on). `child` accepts a first name or a directedId.
- **`alexa_media.amazon_kids_disable`** (`entity_id`) — unassigns the device (turns Amazon Kids off).

## Notes
- Bumps `alexapy` to `1.30.0` for the new methods (`get_child_mode` / `disable_child_mode` / `get_child_profiles` / `get_device_child` / `enable_child_mode`).
- The binary_sensor polls per device independently of the main coordinator.

## Testing
- `black` / `isort` clean; rebased on current `dev`.
- Loaded and verified live in a real HA instance: alexapy auto-upgrades to 1.30.0, all 7 Echo sensors report the correct per-device state, and the enable/disable services work end-to-end (incl. the parent-dashboard CSRF bootstrap for enable).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Amazon Kids (child mode) status sensors for supported Echo devices.
  * Added services to enable or disable Amazon Kids on selected Alexa devices.
  * Enable supports choosing a child profile by first name (or directed profile id).
  * Child mode sensor states update periodically and only show availability after the first successful fetch.
* **Documentation**
  * Added user-facing service descriptions and required fields for the Amazon Kids enable/disable actions.
* **Chores**
  * Updated the underlying `alexapy` dependency to a newer version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->