### PR TITLE
fix: Bump `alexapy` to 1.30.0

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -21,7 +21,7 @@ Always reference these instructions first and fallback to search or bash command
   - `poetry install` -- takes 2-3 minutes on first run. NEVER CANCEL. Set timeout to 10+ minutes.
   - If Poetry fails due to version conflicts: `poetry lock --no-update` first, then `poetry install`
 - **FALLBACK**: Install core dependencies manually if Poetry fails:
-  - `pip3 install alexapy==1.29.25 packaging wrapt async_timeout aiohttp "dictor>=0.1.12,<0.2"`
+  - `pip3 install alexapy==1.30.0 packaging wrapt async_timeout aiohttp "dictor>=0.1.12,<0.2"`
   - This allows basic functionality but may miss dev dependencies
 
 ### Linting and Code Quality (ALWAYS run before committing)
@@ -109,7 +109,7 @@ cat custom_components/alexa_media/manifest.json  # HA integration manifest
 
 ### Dependency Management
 
-- **Core dependencies**: alexapy==1.29.25, aiohttp>=3.8.1, packaging>=20.3, wrapt>=1.14.0, dictor>=0.1.12,<0.2
+- **Core dependencies**: alexapy==1.30.0, aiohttp>=3.8.1, packaging>=20.3, wrapt>=1.14.0, dictor>=0.1.12,<0.2
 - **Dev dependencies**: homeassistant>=2025.2.0, pytest-homeassistant-custom-component>=0.13.107
 - Add new dependencies to `pyproject.toml` then run `poetry lock`
 - **NEVER CANCEL**: `poetry lock` can take 60+ seconds. Set timeout to 10+ minutes.

--- a/custom_components/alexa_media/manifest.json
+++ b/custom_components/alexa_media/manifest.json
@@ -9,7 +9,7 @@
   "issue_tracker": "https://github.com/alandtse/alexa_media_player/issues",
   "loggers": ["alexapy", "authcaptureproxy"],
   "requirements": [
-    "alexapy==1.29.25",
+    "alexapy==1.30.0",
     "packaging>=20.3",
     "wrapt>=1.14.0",
     "dictor>=0.1.12,<0.2"

--- a/poetry.lock
+++ b/poetry.lock
@@ -283,14 +283,14 @@ tzdata = ">=2024.1"
 
 [[package]]
 name = "alexapy"
-version = "1.29.25"
+version = "1.30.0"
 description = "Python API to control Amazon Echo Devices Programmatically."
 optional = false
 python-versions = "<4,>=3.11"
 groups = ["main"]
 files = [
-    {file = "alexapy-1.29.25-py3-none-any.whl", hash = "sha256:ec7903692541178e6dcd7e46097de2cead4aad011367a78f07cb4356bc8a30ef"},
-    {file = "alexapy-1.29.25.tar.gz", hash = "sha256:2b5740663050486677daf67ff2489531426f7750d27248a1d75a19ff127f1076"},
+    {file = "alexapy-1.30.0-py3-none-any.whl", hash = "sha256:10e59b02538b64d63ef5714c61c429ca66c3e0ae7007483bc8ef1783866d2da1"},
+    {file = "alexapy-1.30.0.tar.gz", hash = "sha256:c9badb9ca50b9c1fd702b183f7a43e9931cd39b7d5243c5d3156cfb4ace75b65"},
 ]
 
 [package.dependencies]
@@ -5959,4 +5959,4 @@ ifaddr = ">=0.1.7"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.13,<4.0"
-content-hash = "6c68608511837b8a2296dcd583e654d273f9379745868ff5bd32ba16d11dcd27"
+content-hash = "b580d26ae31b1fff27767b7154df9a908f840fc7abad4b4bda1e707c291b5848"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ packages = [
 
 [tool.poetry.dependencies]
 python = ">=3.13,<4.0"
-alexapy = "1.29.25"
+alexapy = "1.30.0"
 aiohttp = ">=3.8.1"
 packaging = ">=20.3"
 wrapt = ">=1.14.0"


### PR DESCRIPTION
## Bump: [AlexaPy 1.30.0](https://pypi.org/project/AlexaPy/1.30.0/)

- [x] Update alexapy version in `pyproject.toml`
- [x] Update alexapy version in `custom_components/alexa_media/manifest.json`
- [x] Update alexapy version in `.github/copilot-instructions.md` (documentation)
- [x] Update `poetry.lock` properly using `poetry update alexapy` command (not manually)
- [x] Verify linting passes (yamllint, codespell, prettier)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Alexa integration’s underlying Alexa service library to version 1.30.0.
  * Updated setup and dependency documentation to reflect the newer version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->