### PR TITLE
fix: use UnitOfDensity/UnitOfRatio

### DIFF
--- a/custom_components/alexa_media/const.py
+++ b/custom_components/alexa_media/const.py
@@ -26,8 +26,6 @@ try:
 except ImportError:
     from homeassistant.const import (
         CONCENTRATION_MICROGRAMS_PER_CUBIC_METER as _MICROGRAMS_PER_CUBIC_METER,
-    )
-    from homeassistant.const import (
         CONCENTRATION_PARTS_PER_MILLION as _PARTS_PER_MILLION,
     )
 

--- a/custom_components/alexa_media/const.py
+++ b/custom_components/alexa_media/const.py
@@ -11,11 +11,25 @@ from __future__ import annotations
 
 from datetime import timedelta
 
-from homeassistant.const import (
-    CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
-    CONCENTRATION_PARTS_PER_MILLION,
-    PERCENTAGE,
-)
+from homeassistant.const import PERCENTAGE
+
+try:
+    # UnitOfDensity/UnitOfRatio were added in HA 2026.7.0. Below that (this
+    # integration's floor is 2025.2.0), fall back to the equivalent
+    # CONCENTRATION_* constants -- deprecated starting in HA 2026.8 (removed
+    # in 2027.8) but still present as aliases for the same values, and the
+    # only ones that exist pre-2026.7.
+    from homeassistant.const import UnitOfDensity, UnitOfRatio
+
+    _MICROGRAMS_PER_CUBIC_METER = UnitOfDensity.MICROGRAMS_PER_CUBIC_METER
+    _PARTS_PER_MILLION = UnitOfRatio.PARTS_PER_MILLION
+except ImportError:
+    from homeassistant.const import (
+        CONCENTRATION_MICROGRAMS_PER_CUBIC_METER as _MICROGRAMS_PER_CUBIC_METER,
+    )
+    from homeassistant.const import (
+        CONCENTRATION_PARTS_PER_MILLION as _PARTS_PER_MILLION,
+    )
 
 PROJECT_URL = "https://github.com/alandtse/alexa_media_player/"
 ISSUE_URL = f"{PROJECT_URL}issues"
@@ -213,8 +227,8 @@ AUTH_PROXY_NAME = "auth:alexamedia:proxy"
 
 ALEXA_UNIT_CONVERSION = {
     "Alexa.Unit.Percent": PERCENTAGE,
-    "Alexa.Unit.PartsPerMillion": CONCENTRATION_PARTS_PER_MILLION,
-    "Alexa.Unit.Density.MicroGramsPerCubicMeter": CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+    "Alexa.Unit.PartsPerMillion": _PARTS_PER_MILLION,
+    "Alexa.Unit.Density.MicroGramsPerCubicMeter": _MICROGRAMS_PER_CUBIC_METER,
 }
 
 ALEXA_ICON_CONVERSION = {

--- a/tests/test_const.py
+++ b/tests/test_const.py
@@ -8,6 +8,7 @@ from custom_components.alexa_media.const import (
     ALEXA_AIR_QUALITY_DEVICE_CLASS,
     ALEXA_COMPONENTS,
     ALEXA_ICON_CONVERSION,
+    ALEXA_UNIT_CONVERSION,
     CONF_ACCOUNTS,
     CONF_DEBUG,
     CONF_EXCLUDE_DEVICES,
@@ -213,3 +214,84 @@ class TestAirQualityConstants:
             assert ALEXA_ICON_CONVERSION[sensor_type] is not None
             assert isinstance(ALEXA_ICON_CONVERSION[sensor_type], str)
             assert ALEXA_ICON_CONVERSION[sensor_type].startswith("mdi:")
+
+
+class TestUnitConversionConstants:
+    """Test ALEXA_UNIT_CONVERSION (#3535: HA 2026.8 deprecated CONCENTRATION_* units)."""
+
+    def test_alexa_unit_conversion_has_required_mappings(self):
+        """Test that all three Alexa unit strings resolve to a value."""
+        required_units = [
+            "Alexa.Unit.Percent",
+            "Alexa.Unit.PartsPerMillion",
+            "Alexa.Unit.Density.MicroGramsPerCubicMeter",
+        ]
+        for unit in required_units:
+            assert unit in ALEXA_UNIT_CONVERSION
+            assert ALEXA_UNIT_CONVERSION[unit] is not None
+
+    def test_alexa_unit_conversion_values(self):
+        """Test the mapping resolves to the correct unit strings, independent
+        of which Home Assistant version supplied the constant.
+
+        UnitOfDensity/UnitOfRatio (added in HA 2026.7.0) and the
+        CONCENTRATION_MICROGRAMS_PER_CUBIC_METER / CONCENTRATION_PARTS_PER_MILLION
+        constants they deprecate (removed in HA 2027.8) carry the same values
+        on every HA version that defines either. const.py picks whichever
+        pair the running HA version has; this asserts on the value itself so
+        the test passes regardless of which branch is live in the
+        environment running it.
+
+        The density unit's micro sign is intentionally not hardcoded as a
+        literal here -- U+00B5 MICRO SIGN and U+03BC GREEK SMALL LETTER MU
+        are visually identical and easy to type the wrong one of by hand
+        (caught by this exact test during review). Comparing against the
+        actual imported HA constant sidesteps that entirely.
+        """
+        assert ALEXA_UNIT_CONVERSION["Alexa.Unit.PartsPerMillion"] == "ppm"
+
+        try:
+            from homeassistant.const import UnitOfDensity
+
+            expected_density_unit = UnitOfDensity.MICROGRAMS_PER_CUBIC_METER
+        except ImportError:
+            from homeassistant.const import CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
+
+            expected_density_unit = CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
+
+        assert (
+            ALEXA_UNIT_CONVERSION["Alexa.Unit.Density.MicroGramsPerCubicMeter"]
+            == expected_density_unit
+        )
+
+    def test_unit_fallback_matches_whichever_homeassistant_const_has(self):
+        """#3535: const.py must resolve to real objects either way.
+
+        This integration's floor is HA 2025.2.0, but UnitOfDensity/UnitOfRatio
+        only exist from 2026.7.0 onward -- importing them unconditionally
+        would raise ImportError on every older supported version. Confirm
+        const.py's resolved constants equal whichever of the two pairs
+        homeassistant.const actually provides in this environment.
+        """
+        from custom_components.alexa_media.const import (
+            _MICROGRAMS_PER_CUBIC_METER,
+            _PARTS_PER_MILLION,
+        )
+
+        try:
+            from homeassistant.const import UnitOfDensity, UnitOfRatio
+
+            assert _PARTS_PER_MILLION == UnitOfRatio.PARTS_PER_MILLION
+            assert (
+                _MICROGRAMS_PER_CUBIC_METER == UnitOfDensity.MICROGRAMS_PER_CUBIC_METER
+            )
+        except ImportError:
+            from homeassistant.const import (
+                CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+                CONCENTRATION_PARTS_PER_MILLION,
+            )
+
+            assert _PARTS_PER_MILLION == CONCENTRATION_PARTS_PER_MILLION
+            assert (
+                _MICROGRAMS_PER_CUBIC_METER == CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
+            )


### PR DESCRIPTION
## Summary

Closes #3535. HA Core 2026.8 deprecates `CONCENTRATION_MICROGRAMS_PER_CUBIC_METER` and `CONCENTRATION_PARTS_PER_MILLION` (removed in 2027.8), logging a warning every time either is used -- which `const.py`'s `ALEXA_UNIT_CONVERSION` dict does unconditionally at import time, so every startup logs both.

The replacements, `UnitOfDensity`/`UnitOfRatio`, aren't actually usable as a straight swap: I checked when they were added to `homeassistant.const` (binary search across published `homeassistant` versions on PyPI) and they only exist from **2026.7.0** onward. This integration's declared floor in `pyproject.toml` is `homeassistant = ">=2025.2.0"` -- so importing the new names unconditionally, as my first pass at this did, would trade a benign deprecation warning for a hard `ImportError` on every HA version between 2025.2.0 and 2026.6.x. Fixed by trying the new import first and falling back to the deprecated one on `ImportError`; both pairs resolve to the identical unit strings on any HA version that defines either (`"μg/m³"` / `"ppm"`), verified against real installs of both 2025.4.4 (this repo's currently pinned/tested version, which only has the old names) and 2026.8.1 (which only offers a warning on the old names, not yet a hard removal, but does have the new ones).

## Testing

- `tests/test_const.py`: added `TestUnitConversionConstants` with 3 tests -- the mapping has all 3 required unit keys, the resolved values match Home Assistant's actual constant (not a hardcoded literal -- see note below), and `const.py`'s private fallback variables equal whichever pair `homeassistant.const` provides in the running environment.
- Verified both branches for real, not just one: this repo's own pinned/pytest-managed venv (poetry.lock resolves to HA 2025.4.4, which lacks `UnitOfDensity`/`UnitOfRatio`) exercises the fallback branch end-to-end running the actual test suite. Separately, importing `const.py` in isolation under an ephemeral `homeassistant==2026.8.1` install confirms the new-constant branch resolves correctly too.
- Caught my own bug while writing the first version of this test: I'd hand-typed the micro sign in an expected-value literal as U+03BC (Greek small letter mu, "μ") instead of U+00B5 (the actual micro sign HA uses, "µ") -- visually identical, different codepoint. The test caught it immediately; fixed by comparing against the real imported HA constant instead of a hardcoded string.
- Full suite: 205/205 passed (was 202 before the 3 new tests). `black --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved air-quality unit compatibility across supported Home Assistant versions.
  * Ensured Alexa air-quality measurements use the correct parts-per-million and density units.

* **Maintenance**
  * Updated the `alexapy` dependency to version 1.30.0.
  * Improved release workflow reliability with automatic retry handling.
  * Updated development tooling versions.

* **Tests**
  * Added coverage validating air-quality unit conversions and version compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->