### PR TITLE
fix: Amazon email changes in reauth

### DIFF
--- a/custom_components/alexa_media/config_flow.py
+++ b/custom_components/alexa_media/config_flow.py
@@ -623,6 +623,9 @@ class AlexaMediaFlowHandler(config_entries.ConfigFlow):
         """Handle reauth processing for the config flow."""
         self._save_user_input_to_config(user_input)
         self.config["reauth"] = True
+        self.reauth_entry = self.hass.config_entries.async_get_entry(
+            self.context["entry_id"]
+        )
         reauth_schema = self._update_schema_defaults()
         _LOGGER.debug(
             "Creating reauth form with %s",
@@ -660,7 +663,16 @@ class AlexaMediaFlowHandler(config_entries.ConfigFlow):
         email = login.email
         _LOGGER.debug("Testing login status: %s", login.status)
         if login.status and login.status.get("login_successful"):
-            existing_entry = await self.async_set_unique_id(f"{email} - {login.url}")
+            existing_entry = getattr(self, "reauth_entry", None)
+            _LOGGER.debug(
+                "Reauth existing entry: %s",
+                existing_entry.entry_id if existing_entry else None,
+            )
+            if existing_entry is None:
+                existing_entry = await self.async_set_unique_id(
+                    f"{email} - {login.url}"
+                )
+
             if self.config.get("reauth"):
                 self.config.pop("reauth")
             if self.config.get(CONF_SECURITYCODE):
@@ -681,10 +693,37 @@ class AlexaMediaFlowHandler(config_entries.ConfigFlow):
             )
             self.hass.data[DATA_ALEXAMEDIA].setdefault("accounts", {})
             self.hass.data[DATA_ALEXAMEDIA].setdefault("config_flows", {})
+
             if existing_entry:
+                # During reauth the Amazon email may have changed.
+                # Move the existing, fully initialised runtime account from
+                # the old email key to the new email key before updating the
+                # config entry. This preserves entities/devices/options.
+                old_email = existing_entry.data.get(CONF_EMAIL)
+
+                accounts = self.hass.data[DATA_ALEXAMEDIA]["accounts"]
+
+                if old_email and old_email != email and old_email in accounts:
+                    _LOGGER.debug(
+                        "Moving Alexa runtime account from %s to %s",
+                        hide_email(old_email),
+                        hide_email(email),
+                    )
+                    account_data = accounts.pop(old_email)
+                    account_data["config_entry"] = existing_entry
+                    account_data["login_obj"] = self.login
+                    accounts[email] = account_data
+                else:
+                    if email in accounts:
+                        accounts[email]["login_obj"] = self.login
+
                 self.hass.config_entries.async_update_entry(
-                    existing_entry, data=self.config
+                    existing_entry,
+                    data=self.config,
+                    title=f"{login.email} - {login.url}",
+                    unique_id=f"{login.email} - {login.url}",
                 )
+
                 _LOGGER.debug("Reauth successful for %s", hide_email(email))
                 self.hass.bus.async_fire(
                     "alexa_media_relogin_success",
@@ -696,15 +735,6 @@ class AlexaMediaFlowHandler(config_entries.ConfigFlow):
                     self.hass,
                     notification_id,
                 )
-                if not self.hass.data[DATA_ALEXAMEDIA]["accounts"].get(
-                    self.config[CONF_EMAIL]
-                ):
-                    self.hass.data[DATA_ALEXAMEDIA]["accounts"][
-                        self.config[CONF_EMAIL]
-                    ] = {}
-                self.hass.data[DATA_ALEXAMEDIA]["accounts"][self.config[CONF_EMAIL]][
-                    "login_obj"
-                ] = self.login
                 self.hass.data[DATA_ALEXAMEDIA]["config_flows"][
                     f"{email} - {login.url}"
                 ] = None


### PR DESCRIPTION
Reauthentication currently fails when the Amazon account email address has changed.

During reauth, the existing config entry was not correctly associated with the reauth flow because its unique ID was based on the old email address. This could result in Home Assistant attempting to create a new reauth entry.

This change:
- associates the reauth flow with the existing config entry;
- preserves the existing runtime account when the Amazon email changes;
- updates the config entry with the new email and unique ID; and
- reloads the integration after successful reauthentication.

Tested on Home Assistant 2026.9.1 with Alexa Media Player 5.15.7. Reauthentication with a changed Amazon email now completes successfully, with the existing devices and entities retained.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved account reauthentication handling and reliability.
  - Prevented credentials from being assigned to a different existing account.
  - Preserved account state when the Amazon email address changes.
  - Updated connected account details after successful reauthentication.
  - Reloaded the integration after account changes so updated credentials and settings are applied consistently.
  - Improved recovery when retrying authentication for an existing account.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->